### PR TITLE
[Feat/#1] entity setting

### DIFF
--- a/src/main/java/com/lckback/lckforall/LckForAllApplication.java
+++ b/src/main/java/com/lckback/lckforall/LckForAllApplication.java
@@ -2,8 +2,10 @@ package com.lckback.lckforall;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class LckForAllApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/lckback/lckforall/base/model/BaseEntity.java
+++ b/src/main/java/com/lckback/lckforall/base/model/BaseEntity.java
@@ -1,0 +1,27 @@
+package com.lckback.lckforall.base.model;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+	@CreatedDate
+	@Column(updatable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/lckback/lckforall/base/type/PlayerRole.java
+++ b/src/main/java/com/lckback/lckforall/base/type/PlayerRole.java
@@ -1,0 +1,5 @@
+package com.lckback.lckforall.base.type;
+
+public enum PlayerRole {
+	LCK_ROSTER, COACH, LCK_CL_ROSTER
+}

--- a/src/main/java/com/lckback/lckforall/base/type/UserRole.java
+++ b/src/main/java/com/lckback/lckforall/base/type/UserRole.java
@@ -1,0 +1,5 @@
+package com.lckback.lckforall.base.type;
+
+public enum UserRole {
+	ROLE_USER, ROLE_ADMIN
+}

--- a/src/main/java/com/lckback/lckforall/base/type/UserStatus.java
+++ b/src/main/java/com/lckback/lckforall/base/type/UserStatus.java
@@ -1,0 +1,5 @@
+package com.lckback.lckforall.base.type;
+
+public enum UserStatus {
+	ACTIVE, INACTIVE
+}

--- a/src/main/java/com/lckback/lckforall/community/model/Comment.java
+++ b/src/main/java/com/lckback/lckforall/community/model/Comment.java
@@ -1,0 +1,53 @@
+package com.lckback.lckforall.community.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.lckback.lckforall.base.model.BaseEntity;
+import com.lckback.lckforall.report.model.CommentReport;
+import com.lckback.lckforall.user.model.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@Entity
+@Table(name = "COMMENTS")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, columnDefinition = "TEXT")
+	private String content;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "POST_ID", nullable = false)
+	private Post post;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "USER_ID", nullable = false)
+	private User user;
+
+	@OneToMany(mappedBy = "comment")
+	private List<CommentReport> commentReports = new ArrayList<>();
+}

--- a/src/main/java/com/lckback/lckforall/community/model/Post.java
+++ b/src/main/java/com/lckback/lckforall/community/model/Post.java
@@ -1,0 +1,62 @@
+package com.lckback.lckforall.community.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.lckback.lckforall.base.model.BaseEntity;
+import com.lckback.lckforall.report.model.PostReport;
+import com.lckback.lckforall.user.model.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@Entity
+@Table(name = "POSTS")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Post extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, length = 20)
+	private String title;
+
+	@Column(nullable = false, columnDefinition = "TEXT")
+	private String content;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "POST_TYPE_ID", nullable = false)
+	private PostType postType;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "USER_ID", nullable = false)
+	private User user;
+
+	@OneToMany(mappedBy = "post")
+	private List<Comment> comments = new ArrayList<>();
+
+	@OneToMany(mappedBy = "post")
+	private List<PostFile> postFiles = new ArrayList<>();
+
+	@OneToMany(mappedBy = "post")
+	private List<PostReport> postReports = new ArrayList<>();
+}

--- a/src/main/java/com/lckback/lckforall/community/model/PostFile.java
+++ b/src/main/java/com/lckback/lckforall/community/model/PostFile.java
@@ -1,0 +1,40 @@
+package com.lckback.lckforall.community.model;
+
+import com.lckback.lckforall.base.model.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@Entity
+@Table(name = "POST_FILE")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostFile extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private String url;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "POST_ID", nullable = false)
+	private Post post;
+}

--- a/src/main/java/com/lckback/lckforall/community/model/PostType.java
+++ b/src/main/java/com/lckback/lckforall/community/model/PostType.java
@@ -1,0 +1,38 @@
+package com.lckback.lckforall.community.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.lckback.lckforall.base.model.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostType extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, length = 20)
+	private String type;
+
+	@OneToMany(mappedBy = "postType")
+	private List<Post> posts = new ArrayList<>();
+}

--- a/src/main/java/com/lckback/lckforall/match/model/Match.java
+++ b/src/main/java/com/lckback/lckforall/match/model/Match.java
@@ -1,0 +1,66 @@
+package com.lckback.lckforall.match.model;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.lckback.lckforall.base.model.BaseEntity;
+import com.lckback.lckforall.player.model.Player;
+import com.lckback.lckforall.team.model.Team;
+import com.lckback.lckforall.vote.model.MatchPogVote;
+import com.lckback.lckforall.vote.model.MatchVote;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@Entity
+@Table(name = "MATCHES")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Match extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private LocalDateTime matchDate;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "POG_PLAYER_ID", nullable = false)
+	private Player pogPlayer;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "TEAM_ID1", nullable = false)
+	private Team team1;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "TEAM_ID2", nullable = false)
+	private Team team2;
+
+	@OneToMany(mappedBy = "match")
+	private List<Set> sets = new ArrayList<>();
+
+	@OneToMany(mappedBy = "match")
+	private List<MatchPogVote> matchPogVotes = new ArrayList<>();
+
+	@OneToMany(mappedBy = "match")
+	private List<MatchVote> matchVotes = new ArrayList<>();
+}

--- a/src/main/java/com/lckback/lckforall/match/model/Set.java
+++ b/src/main/java/com/lckback/lckforall/match/model/Set.java
@@ -1,0 +1,69 @@
+package com.lckback.lckforall.match.model;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.lckback.lckforall.base.model.BaseEntity;
+import com.lckback.lckforall.player.model.Player;
+import com.lckback.lckforall.team.model.Team;
+import com.lckback.lckforall.vote.model.SetPogVote;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@Entity
+@Table(name = "MATCH_SETS")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Set extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private Integer matchIndex;
+
+	@Column(nullable = false)
+	private LocalDateTime startDate;
+
+	@Column(nullable = false)
+	private LocalDateTime endDate;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "MATCH_ID", nullable = false)
+	private Match match;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "POG_PLAYER_ID", nullable = false)
+	private Player pogPlayer;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "WINNER_TEAM_ID", nullable = false)
+	private Team winnerTeam;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "LOSE_TEAM_ID", nullable = false)
+	private Team loseTeam;
+
+	@OneToMany(mappedBy = "set")
+	private List<SetPogVote> setPogVotes = new ArrayList<>();
+}

--- a/src/main/java/com/lckback/lckforall/player/model/Player.java
+++ b/src/main/java/com/lckback/lckforall/player/model/Player.java
@@ -1,0 +1,69 @@
+package com.lckback.lckforall.player.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.lckback.lckforall.base.model.BaseEntity;
+import com.lckback.lckforall.base.type.PlayerRole;
+import com.lckback.lckforall.match.model.Match;
+import com.lckback.lckforall.match.model.Set;
+import com.lckback.lckforall.team.model.Team;
+import com.lckback.lckforall.vote.model.MatchPogVote;
+import com.lckback.lckforall.vote.model.SetPogVote;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Player extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, length = 20)
+	private String name;
+
+	@Column(nullable = false, length = 100)
+	private String ProfileImageUrl;
+
+	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	private PlayerRole role;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "TEAM_ID", nullable = false)
+	private Team team;
+
+	@OneToMany(mappedBy = "player")
+	private List<SetPogVote> setPogVotes = new ArrayList<>();
+
+	@OneToMany(mappedBy = "player")
+	private List<MatchPogVote> matchPogVotes = new ArrayList<>();
+
+	@OneToMany(mappedBy = "pogPlayer")
+	private List<Match> pogMatches = new ArrayList<>();
+
+	@OneToMany(mappedBy = "pogPlayer")
+	private List<Set> pogSets = new ArrayList<>();
+}

--- a/src/main/java/com/lckback/lckforall/report/model/CommentReport.java
+++ b/src/main/java/com/lckback/lckforall/report/model/CommentReport.java
@@ -1,0 +1,42 @@
+package com.lckback.lckforall.report.model;
+
+import com.lckback.lckforall.base.model.BaseEntity;
+import com.lckback.lckforall.community.model.Comment;
+import com.lckback.lckforall.user.model.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@Entity
+@Table(name = "COMMENT_REPORT")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentReport extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "COMMENT_ID", nullable = false)
+	private Comment comment;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "USER_ID", nullable = false)
+	private User user;
+}

--- a/src/main/java/com/lckback/lckforall/report/model/PostReport.java
+++ b/src/main/java/com/lckback/lckforall/report/model/PostReport.java
@@ -1,0 +1,42 @@
+package com.lckback.lckforall.report.model;
+
+import com.lckback.lckforall.base.model.BaseEntity;
+import com.lckback.lckforall.community.model.Post;
+import com.lckback.lckforall.user.model.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@Entity
+@Table(name = "POST_REPORT")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostReport extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "POST_ID", nullable = false)
+	private Post post;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "USER_ID", nullable = false)
+	private User user;
+}

--- a/src/main/java/com/lckback/lckforall/team/model/Team.java
+++ b/src/main/java/com/lckback/lckforall/team/model/Team.java
@@ -1,0 +1,71 @@
+package com.lckback.lckforall.team.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.lckback.lckforall.base.model.BaseEntity;
+import com.lckback.lckforall.match.model.Match;
+import com.lckback.lckforall.match.model.Set;
+import com.lckback.lckforall.player.model.Player;
+import com.lckback.lckforall.user.model.User;
+import com.lckback.lckforall.vote.model.MatchVote;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Team extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, length = 20)
+	private String teamName;
+
+	@Column(nullable = false, length = 100)
+	private String teamLogoUrl;
+
+	@Column(nullable = false, length = 100)
+	private String season;
+
+	@Column(nullable = false)
+	private Integer winningPoint;
+
+	@OneToMany(mappedBy = "team")
+	private List<User> users = new ArrayList<>();
+
+	@OneToMany(mappedBy = "team")
+	private List<Player> players = new ArrayList<>();
+
+	@OneToMany(mappedBy = "winnerTeam")
+	private List<Set> winSets = new ArrayList<>();
+
+	@OneToMany(mappedBy = "loseTeam")
+	private List<Set> loseSets = new ArrayList<>();
+
+	@OneToMany(mappedBy = "team")
+	private List<MatchVote> matchVotes = new ArrayList<>();
+
+	@OneToMany(mappedBy = "team1")
+	private List<Match> matches1 = new ArrayList<>();
+
+	@OneToMany(mappedBy = "team2")
+	private List<Match> matches2 = new ArrayList<>();
+
+}

--- a/src/main/java/com/lckback/lckforall/user/model/User.java
+++ b/src/main/java/com/lckback/lckforall/user/model/User.java
@@ -1,0 +1,96 @@
+package com.lckback.lckforall.user.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.lckback.lckforall.base.model.BaseEntity;
+import com.lckback.lckforall.base.type.UserRole;
+import com.lckback.lckforall.base.type.UserStatus;
+import com.lckback.lckforall.community.model.Comment;
+import com.lckback.lckforall.community.model.Post;
+import com.lckback.lckforall.report.model.CommentReport;
+import com.lckback.lckforall.report.model.PostReport;
+import com.lckback.lckforall.team.model.Team;
+import com.lckback.lckforall.viewing.model.Participate;
+import com.lckback.lckforall.viewing.model.ViewingParty;
+import com.lckback.lckforall.vote.model.MatchPogVote;
+import com.lckback.lckforall.vote.model.MatchVote;
+import com.lckback.lckforall.vote.model.SetPogVote;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Builder
+@Table(name = "USERS")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, length = 20)
+	private String nickname;
+
+	@Column(nullable = false, length = 100)
+	private String profileImageUrl;
+
+	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	private UserRole role;
+
+	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	private UserStatus status;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "TEAM_ID", nullable = false)
+	private Team team;
+
+	@OneToMany(mappedBy = "user")
+	private List<Post> posts = new ArrayList<>();
+
+	@OneToMany(mappedBy = "user")
+	private List<PostReport> postReports = new ArrayList<>();
+
+	@OneToMany(mappedBy = "user")
+	private List<Comment> comments = new ArrayList<>();
+
+	@OneToMany(mappedBy = "user")
+	private List<CommentReport> commentReports = new ArrayList<>();
+
+	@OneToMany(mappedBy = "user")
+	private List<Participate> participatingViewingParties = new ArrayList<>();
+
+	@OneToMany(mappedBy = "user")
+	private List<ViewingParty> hostingViewingParties = new ArrayList<>();
+
+	@OneToMany(mappedBy = "user")
+	private List<MatchVote> matchVotes = new ArrayList<>();
+
+	@OneToMany(mappedBy = "user")
+	private List<MatchPogVote> matchPogVotes = new ArrayList<>();
+
+	@OneToMany(mappedBy = "user")
+	private List<SetPogVote> setPogVotes = new ArrayList<>();
+}

--- a/src/main/java/com/lckback/lckforall/viewing/model/Participate.java
+++ b/src/main/java/com/lckback/lckforall/viewing/model/Participate.java
@@ -1,0 +1,39 @@
+package com.lckback.lckforall.viewing.model;
+
+import com.lckback.lckforall.base.model.BaseEntity;
+import com.lckback.lckforall.user.model.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Participate extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "VIEWING_PARTY_ID", nullable = false)
+	private ViewingParty viewingParty;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "USER_ID", nullable = false)
+	private User user;
+}

--- a/src/main/java/com/lckback/lckforall/viewing/model/ViewingParty.java
+++ b/src/main/java/com/lckback/lckforall/viewing/model/ViewingParty.java
@@ -1,0 +1,69 @@
+package com.lckback.lckforall.viewing.model;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.geo.Point;
+
+import com.lckback.lckforall.base.model.BaseEntity;
+import com.lckback.lckforall.user.model.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@Entity
+@Table(name = "VIEWING_PARTY")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ViewingParty extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, length = 20)
+	private String name;
+
+	@Column(nullable = false)
+	private LocalDateTime date;
+
+	@Column(nullable = false)
+	private Point location;
+
+	@Column(nullable = false)
+	private Integer price;
+
+	@Column(nullable = false)
+	private Integer limitParticipate;
+
+	@Column(nullable = false, length = 100)
+	private String partyQualify;
+
+	@Column(length = 1000)
+	private String etc;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "USER_ID", nullable = false)
+	private User user;
+
+	@OneToMany(mappedBy = "viewingParty")
+	private List<Participate> participates = new ArrayList<>();
+}

--- a/src/main/java/com/lckback/lckforall/vote/model/MatchPogVote.java
+++ b/src/main/java/com/lckback/lckforall/vote/model/MatchPogVote.java
@@ -1,0 +1,47 @@
+package com.lckback.lckforall.vote.model;
+
+import com.lckback.lckforall.base.model.BaseEntity;
+import com.lckback.lckforall.match.model.Match;
+import com.lckback.lckforall.player.model.Player;
+import com.lckback.lckforall.user.model.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@Entity
+@Table(name = "MATCH_POG_VOTE")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MatchPogVote extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "USER_ID")
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "MATCH_ID")
+	private Match match;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "PLAYER_ID")
+	private Player player;
+}

--- a/src/main/java/com/lckback/lckforall/vote/model/MatchVote.java
+++ b/src/main/java/com/lckback/lckforall/vote/model/MatchVote.java
@@ -1,0 +1,47 @@
+package com.lckback.lckforall.vote.model;
+
+import com.lckback.lckforall.base.model.BaseEntity;
+import com.lckback.lckforall.match.model.Match;
+import com.lckback.lckforall.team.model.Team;
+import com.lckback.lckforall.user.model.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@Entity
+@Table(name = "MATCH_VOTE")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MatchVote extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "MATCH_ID")
+	private Match match;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "USER_ID")
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "TEAM_ID")
+	private Team team;
+}

--- a/src/main/java/com/lckback/lckforall/vote/model/SetPogVote.java
+++ b/src/main/java/com/lckback/lckforall/vote/model/SetPogVote.java
@@ -1,0 +1,47 @@
+package com.lckback.lckforall.vote.model;
+
+import com.lckback.lckforall.base.model.BaseEntity;
+import com.lckback.lckforall.match.model.Set;
+import com.lckback.lckforall.player.model.Player;
+import com.lckback.lckforall.user.model.User;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@Entity
+@Table(name = "SET_POG_VOTE")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SetPogVote extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "USER_ID")
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "SET_ID")
+	private Set set;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "PLAYER_ID")
+	private Player player;
+}


### PR DESCRIPTION
## 개요
BaseEntity 세팅
Erd 기반으로 Entity 세팅
필요한 Enum 세팅
모든 엔티티에 양방향 연관관계 추가
main문에 @EnableJpaAuditing 추가
## 작업사항
1. BaseEntity 세팅
![스크린샷 2024-07-24 오전 1 23 27](https://github.com/user-attachments/assets/42a78655-670d-4e40-9b50-54e2825abd58)
2. Entity 세팅
![스크린샷 2024-07-24 오전 1 24 21](https://github.com/user-attachments/assets/edeb176d-3d2d-443c-9465-586101c3186d)
모든 엔티티는 @Getter ,@Setter, @Builder, @AllArgsConstructor,
@NoArgsConstructor(access = AccessLevel.PROTECTED)
어노테이션이 있고 BaseEntity를 상속
모든 엔티티는 양방향 연관관계 매핑이 되어있음
@Table 은 mysql과 겹치는 것들이 있어서 그부분과 datagrip에서 인식 안되는 것들만 따로 수정했습니다
## 변경로직
1. BaseEntity의 CreatedAt, UpdatedAt 자동 업데이트를 위해서 @EnableJpaAuditing 추가
### 변경 전

### 변경 후
![스크린샷 2024-07-24 오전 1 27 18](https://github.com/user-attachments/assets/e3ab14a2-dc61-47ec-83a1-b1381c5b08fc)
## 사용방법

## 기타
### 회의를 통해 조정해 보면 좋을 부분들
1. Team 엔티티의 연관관계
Erd에서 Team 엔티티와 Match 엔티티는 Team1, Team2로 두개의 외래키로 매핑되어 있습니다
그래서 Team의 연관관계 매핑을 아래와 같이 했습니다
![스크린샷 2024-07-24 오전 1 31 23](https://github.com/user-attachments/assets/e2770511-468b-4420-a145-bf9fc762dc7e)
근데 이게 match1과 match2 이렇게 두개로 나뉘는게 애매해서 
```
@Transient  
private List<Match> allMatches = new ArrayList<>();  
  
@PostLoad  
public void sumMatches() {  
    this.allMatches.addAll(matches1);  
    this.allMatches.addAll(matches2);  
}
```
이런 식으로 로딩될때 모든 매치들을 가져오는 방식이 좋을지 아니면 따로 비즈니스 로직을 작성하는게 좋을지 모르겠어요
위처럼 @Transient를 사용하면 조회는 편하게 가능한데 영속 대상에서 제외돼서 어차피 match를 수정할때 다시 match1, match2를 수정해야 하는 단점이 있습니다.
3. Setter 어노테이션
혹시 몰라서 Setter 어노테이션을 붙였는데 원래는 비즈니스 메서드를 따로 만드는 경우도 많다고 하더라구요. 그래서 이건 회의하면서 어떻게 진행해야 될지 정해야 할 것 같습니다.
4. ViewingParty 엔티티의 공간정보
지도 api에서 공간정보를 어떻게 주는지 몰라 일단 Point라는 클래스가 있길래 그걸로 코드 작성했는데 혹시 어떻게 하는지 아시는분 있으면 수정하겠습니다.
5. 양방향 매핑
어떻게 사용할지 몰라 전부 양방향 매핑을 걸었는데 몇개는 안써도 될거같은게 있더라구요 그래도 혹시 몰라서 전부 작성했습니다.