### PR TITLE
[Feat/#9] unified API response format

### DIFF
--- a/src/main/java/com/lckback/lckforall/base/api/ApiResponse.java
+++ b/src/main/java/com/lckback/lckforall/base/api/ApiResponse.java
@@ -1,0 +1,37 @@
+package com.lckback.lckforall.base.api;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ApiResponse<T> {
+
+    private static final boolean SUCCESS_STATUS = true;
+
+    private static final boolean FAIL_STATUS = false;
+
+    private static final String SUCCESS_MESSAGE = "API 호출 성공";
+
+    private boolean isSuccess;
+
+    private String message;
+
+    private T data;
+
+    public static <T> ApiResponse<T> createSuccess(T data) {
+        return new ApiResponse<>(SUCCESS_STATUS, SUCCESS_MESSAGE, data);
+    }
+
+    public static ApiResponse<?> createSuccessWithNoContent() {
+        return new ApiResponse<>(SUCCESS_STATUS, SUCCESS_MESSAGE, null);
+    }
+
+    public static ApiResponse<?> createFail(String message) {
+        return new ApiResponse<>(FAIL_STATUS, message, null);
+    }
+
+}


### PR DESCRIPTION
## 개요
통일된 API 응답 형식 추가

## 작업사항
base/api dir에 ApiResponse 추가

## 변경로직

### 변경 전

### 변경 후

## 사용방법
컨트롤러에서 정상적인 응답 반환시에는 createSuccess() or createSuccessWithNoContent()
예외 핸들러에서 예외 응답 반환시에는 createFail() 

## 기타