### PR TITLE
[Feat/#11] add RestApiException with ErrorCode

### DIFF
--- a/src/main/java/com/lckback/lckforall/base/api/ApiResponse.java
+++ b/src/main/java/com/lckback/lckforall/base/api/ApiResponse.java
@@ -1,5 +1,7 @@
 package com.lckback.lckforall.base.api;
 
+import com.lckback.lckforall.base.api.error.ErrorCode;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -28,6 +30,10 @@ public class ApiResponse<T> {
 
     public static ApiResponse<?> createSuccessWithNoContent() {
         return new ApiResponse<>(SUCCESS_STATUS, SUCCESS_MESSAGE, null);
+    }
+
+    public static ApiResponse<?> createFail(ErrorCode errorCode) {
+        return new ApiResponse<>(FAIL_STATUS, errorCode.getMessage(), null);
     }
 
     public static ApiResponse<?> createFail(String message) {

--- a/src/main/java/com/lckback/lckforall/base/api/error/CommonErrorCode.java
+++ b/src/main/java/com/lckback/lckforall/base/api/error/CommonErrorCode.java
@@ -1,0 +1,19 @@
+package com.lckback.lckforall.base.api.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "파라미터가 올바르지 않습니다."),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "찾을 수 없는 리소스입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않는 HTTP Method입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/lckback/lckforall/base/api/error/ErrorCode.java
+++ b/src/main/java/com/lckback/lckforall/base/api/error/ErrorCode.java
@@ -1,0 +1,12 @@
+package com.lckback.lckforall.base.api.error;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+
+    String name();
+
+    HttpStatus getHttpStatus();
+
+    String getMessage();
+}

--- a/src/main/java/com/lckback/lckforall/base/api/exception/RestApiException.java
+++ b/src/main/java/com/lckback/lckforall/base/api/exception/RestApiException.java
@@ -1,0 +1,13 @@
+package com.lckback.lckforall.base.api.exception;
+
+import com.lckback.lckforall.base.api.error.ErrorCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RestApiException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+}


### PR DESCRIPTION
## 개요
API 호출 과정에서 발생하는 예외를 처리하기 위한 custom exception 및 error code 정의

## 작업사항
1. 앞으로 추가 될 모든 error code를 위한 ErrorCode interface
2. 가장 흔하게 발생하는 CommonErrorCode
3. RuntimeException을 상속 받는 RestApiException 추가(내부 필드로 ErrorCode)

## 변경로직

### 변경 전

### 변경 후

## 사용방법
비즈니스 로직에서 예외 발생시 `ex) throw new RestApiException(CommonErrorCode.METHOD_NOT_ALLOWED)`

## 기타
resolved : #11 