### PR TITLE
[Feat/#16] : 스웨거 활용 예시 구현

### DIFF
--- a/src/main/java/com/lckback/lckforall/viewing/ViewingController.java
+++ b/src/main/java/com/lckback/lckforall/viewing/ViewingController.java
@@ -1,0 +1,32 @@
+package com.lckback.lckforall.viewing;
+
+import com.lckback.lckforall.base.api.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/viewing")
+public class ViewingController {
+
+    // 기능 API
+    @GetMapping("/alarm")
+    @Operation(summary = "뷰잉파티 조회 API", description = "뷰잉파티를 조회하는 API이며, 페이징을 포함합니다. query String 으로 page 번호를 주세요")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "VIEWING4001", description = "NOT_FOUND, 뷰잉파티글을 찾을 수 없습니다."),
+
+    })
+    @Parameters({
+            @Parameter(name = "page", description = "query string(RequestParam) - 몇번째 페이지인지 가리키는 page 변수 (0부터 시작)"),
+            @Parameter(name = "userId", description = "RequestHeader - 로그인한 사용자 아이디(accessToken으로 변경 예정)")
+    })
+    public ApiResponse<String> testSwagger(@RequestHeader("userId") Long userId,
+                                           @RequestParam(name = "page") Integer page){
+        return ApiResponse.createSuccess("사용자 아이디 : %d, 페이지 번호 : %d".formatted(userId,page));
+    }
+}


### PR DESCRIPTION
## 개요
Restful API를 구현하기 이전 가장 처음에 작성하는 스웨거 양식 코드입니다.

## 작업사항
예시로는 로그인 기능이 구현되기 전까지 임시로 사용될 파라미터로 전달받는 헤더에 관해서 설명을 넣어주었습니다.

## 변경로직

### 변경 전

### 변경 후

## 사용방법
http://localhost:8080/swagger-ui/index.html#/ 
접속후 다음과 같이 설명이 적힌 화면을 확인할 수 있습니다.
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/2703ab2f-bf7d-4952-b882-3b23460b965d">


## 기타
resolved : #16