### PR TITLE
👷 [Ci/#21] PUSH 및 PR 이벤트 수정

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,11 +1,6 @@
 name: Continuous Integration
 
 on:
-#  push:
-#    # develop, prod를 제외한 모든 브랜치에 push 이벤트 시 동작
-#    branches-ignore:
-#      - develop
-#      - prod
   # develop 브랜치에 대해 pr 이벤트 시 동작
   pull_request:
     branches:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,14 +1,16 @@
 name: Continuous Integration
 
 on:
-  push:
-    # develop, prod를 제외한 모든 브랜치에 push 이벤트 시 동작
-    branches-ignore:
-      - develop
-      - prod
+#  push:
+#    # develop, prod를 제외한 모든 브랜치에 push 이벤트 시 동작
+#    branches-ignore:
+#      - develop
+#      - prod
   # develop 브랜치에 대해 pr 이벤트 시 동작
   pull_request:
-    branches: ["develop"]
+    branches:
+      - develop
+    types: [opened, reopened, synchronize, closed]
 
 permissions:
   contents: read


### PR DESCRIPTION
## 개요
현재 develop에 관련된 브랜치가 생성되는 즉시 깃허브 액션이 돌아가는 상황
ex)
![image](https://github.com/user-attachments/assets/bf528562-7690-439c-b4d4-c6a702d36fac)

- 불필요한 push event가 많은 상황
- push 시 CI는 주로 main, dev, prod 등 중요 브랜치에서만 한다고 합니다
    - develop으로 바로 push가 막혀있으니 굳이 필요없는 이벤트라고 판단
## 작업사항
필요없는 push event 삭제 및 pull request event 설정 변경

## 변경로직
1. push event 삭제
    - develop으로 바로 push는 금지되어있기 때문에 필요없는 이벤트라 판단
2. PR event 설정 수정
3. 서브모듈 업데이트
### 변경 전
```java
  push:
    branches-ignore:
      - develop
      - prod
  pull_request:
    branches:
      - develop
```
### 변경 후
```java
  pull_request:
    branches:
      - develop
    types: [opened, reopened, synchronize, closed]
```
opened: 새로운 PR이 열릴 때
reopened: 닫혔던 PR이 다시 열릴 때
synchronize: PR에 새로운 커밋이 추가될 때
closed: PR이 닫힐 때
## 사용방법

## 기타