### PR TITLE
[Feat/#27] get user's profile

### DIFF
--- a/src/main/java/com/lckback/lckforall/mypage/controller/MyPageController.java
+++ b/src/main/java/com/lckback/lckforall/mypage/controller/MyPageController.java
@@ -1,0 +1,35 @@
+package com.lckback.lckforall.mypage.controller;
+
+import com.lckback.lckforall.base.api.ApiResponse;
+import com.lckback.lckforall.mypage.dto.GetUserProfileDto;
+import com.lckback.lckforall.mypage.service.MyPageService;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@CrossOrigin("*")
+@RequestMapping("/my-pages")
+@RequiredArgsConstructor
+public class MyPageController {
+
+    private final MyPageService myPageService;
+
+    @GetMapping("/profiles")
+    public ResponseEntity<?> getUserProfile(
+        @RequestHeader(name = "userId") Long userId) {
+
+        GetUserProfileDto.Response response =
+            myPageService.getUserProfile(userId);
+
+        return ResponseEntity.ok()
+            .body(ApiResponse.createSuccess(response));
+    }
+
+}

--- a/src/main/java/com/lckback/lckforall/mypage/dto/GetUserProfileDto.java
+++ b/src/main/java/com/lckback/lckforall/mypage/dto/GetUserProfileDto.java
@@ -1,0 +1,15 @@
+package com.lckback.lckforall.mypage.dto;
+
+import lombok.Builder;
+
+public class GetUserProfileDto {
+
+    @Builder
+    public static class Response {
+
+        private String nickname;
+        private String profileImageUrl;
+        private String teamLogoUrl;
+        private String tier;
+    }
+}

--- a/src/main/java/com/lckback/lckforall/mypage/service/MyPageService.java
+++ b/src/main/java/com/lckback/lckforall/mypage/service/MyPageService.java
@@ -1,0 +1,32 @@
+package com.lckback.lckforall.mypage.service;
+
+import com.lckback.lckforall.base.api.error.CommonErrorCode;
+import com.lckback.lckforall.base.api.exception.RestApiException;
+import com.lckback.lckforall.mypage.dto.GetUserProfileDto;
+import com.lckback.lckforall.user.model.User;
+import com.lckback.lckforall.user.respository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+
+    private final UserRepository userRepository;
+
+    public GetUserProfileDto.Response getUserProfile(Long userId) {
+
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+
+        return GetUserProfileDto.Response.builder()
+            .nickname(user.getNickname())
+            .profileImageUrl(user.getProfileImageUrl())
+            .teamLogoUrl(user.getTeam().getTeamLogoUrl())
+            .tier("temp")
+            .build();
+    }
+
+}

--- a/src/main/java/com/lckback/lckforall/user/model/User.java
+++ b/src/main/java/com/lckback/lckforall/user/model/User.java
@@ -43,52 +43,60 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-	@Column(nullable = false, length = 20)
-	private String nickname;
+    @Column(nullable = false, length = 20)
+    private String nickname;
 
-	@Column(nullable = false, length = 100)
-	private String profileImageUrl;
+    @Column(nullable = false, length = 100)
+    private String profileImageUrl;
 
-	@Column(nullable = false)
-	@Enumerated(EnumType.STRING)
-	private UserRole role;
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private UserRole role;
 
-	@Column(nullable = false)
-	@Enumerated(EnumType.STRING)
-	private UserStatus status;
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private UserStatus status;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "TEAM_ID", nullable = false)
-	private Team team;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "TEAM_ID", nullable = false)
+    private Team team;
 
-	@OneToMany(mappedBy = "user")
-	private List<Post> posts = new ArrayList<>();
+    @OneToMany(mappedBy = "user")
+    private List<Post> posts = new ArrayList<>();
 
-	@OneToMany(mappedBy = "user")
-	private List<PostReport> postReports = new ArrayList<>();
+    @OneToMany(mappedBy = "user")
+    private List<PostReport> postReports = new ArrayList<>();
 
-	@OneToMany(mappedBy = "user")
-	private List<Comment> comments = new ArrayList<>();
+    @OneToMany(mappedBy = "user")
+    private List<Comment> comments = new ArrayList<>();
 
-	@OneToMany(mappedBy = "user")
-	private List<CommentReport> commentReports = new ArrayList<>();
+    @OneToMany(mappedBy = "user")
+    private List<CommentReport> commentReports = new ArrayList<>();
 
-	@OneToMany(mappedBy = "user")
-	private List<Participate> participatingViewingParties = new ArrayList<>();
+    @OneToMany(mappedBy = "user")
+    private List<Participate> participatingViewingParties = new ArrayList<>();
 
-	@OneToMany(mappedBy = "user")
-	private List<ViewingParty> hostingViewingParties = new ArrayList<>();
+    @OneToMany(mappedBy = "user")
+    private List<ViewingParty> hostingViewingParties = new ArrayList<>();
 
-	@OneToMany(mappedBy = "user")
-	private List<MatchVote> matchVotes = new ArrayList<>();
+    @OneToMany(mappedBy = "user")
+    private List<MatchVote> matchVotes = new ArrayList<>();
 
-	@OneToMany(mappedBy = "user")
-	private List<MatchPogVote> matchPogVotes = new ArrayList<>();
+    @OneToMany(mappedBy = "user")
+    private List<MatchPogVote> matchPogVotes = new ArrayList<>();
 
-	@OneToMany(mappedBy = "user")
-	private List<SetPogVote> setPogVotes = new ArrayList<>();
+    @OneToMany(mappedBy = "user")
+    private List<SetPogVote> setPogVotes = new ArrayList<>();
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
 }

--- a/src/main/java/com/lckback/lckforall/user/respository/UserRepository.java
+++ b/src/main/java/com/lckback/lckforall/user/respository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.lckback.lckforall.user.respository;
+
+import com.lckback.lckforall.user.model.User;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}


### PR DESCRIPTION
## 개요
화면설계서 마이페이지_1 : 사용자의 프로필 정보를 읽어오는 API 구현

## 작업사항
1. UserRepository 추가
2. User 엔티티에 nickname, profileImageUrl 업데이트 메서드 구현
3. GetUserProfile DTO 추가
4. MyPageService 추가 및 getUserProfile() 구현
5. MyPageController 추가 및 getUserProfile() 구현

## 변경로직

### 변경 전

### 변경 후

## 사용방법
`/my-pages/profiles` URL에 `Get` method로 request

## 기타
access token 도입 전까지 `@RequestHeader`를 `userId`로 임시 구현

resolved : #27 