### PR TITLE
[Feat/#19] about lck team informantion

### DIFF
--- a/src/main/java/com/lckback/lckforall/aboutlck/controller/AboutLckMatchController.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/controller/AboutLckMatchController.java
@@ -3,6 +3,7 @@ package com.lckback.lckforall.aboutlck.controller;
 import java.time.LocalDate;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,13 +13,14 @@ import com.lckback.lckforall.base.api.ApiResponse;
 
 import lombok.RequiredArgsConstructor;
 
-@RestController("/aboutlck/match")
+@RestController
+@RequestMapping("/aboutlck/match")
 @RequiredArgsConstructor
 public class AboutLckMatchController {
 
 	private final AboutLckMatchService aboutLckMatchService;
 
-	@GetMapping("/")
+	@GetMapping
 	public ApiResponse<FindMatchesByDateDto.Response> findMatchInformationByDate(
 		@RequestParam("searchDate") LocalDate searchDate) {
 		FindMatchesByDateDto.Parameter param = FindMatchesByDateDto.Parameter.builder().searchDate(searchDate).build();

--- a/src/main/java/com/lckback/lckforall/aboutlck/controller/AboutLckMatchController.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/controller/AboutLckMatchController.java
@@ -20,7 +20,7 @@ public class AboutLckMatchController {
 
 	private final AboutLckMatchService aboutLckMatchService;
 
-	@GetMapping
+	@GetMapping("/")
 	public ApiResponse<FindMatchesByDateDto.Response> findMatchInformationByDate(
 		@RequestParam("searchDate") LocalDate searchDate) {
 		FindMatchesByDateDto.Parameter param = FindMatchesByDateDto.Parameter.builder().searchDate(searchDate).build();

--- a/src/main/java/com/lckback/lckforall/aboutlck/controller/AboutLckTeamController.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/controller/AboutLckTeamController.java
@@ -1,0 +1,77 @@
+package com.lckback.lckforall.aboutlck.controller;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.lckback.lckforall.aboutlck.dto.FindTeamPlayerHistoryDto;
+import com.lckback.lckforall.aboutlck.dto.FindTeamRatingHistoryDto;
+import com.lckback.lckforall.aboutlck.dto.FindTeamRatingBySeasonDto;
+import com.lckback.lckforall.aboutlck.dto.FindTeamWinningHistoryDto;
+import com.lckback.lckforall.aboutlck.service.AboutLckTeamService;
+import com.lckback.lckforall.base.api.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/aboutlck/team")
+@RequiredArgsConstructor
+public class AboutLckTeamController {
+
+	private final AboutLckTeamService aboutLckTeamService;
+
+	@GetMapping("/rating")
+	public ApiResponse<FindTeamRatingBySeasonDto.Response> findTeamRatingBySeason(
+		@RequestParam("seasonName") String seasonName,
+		Pageable pageable) {
+		FindTeamRatingBySeasonDto.Parameter parameter = FindTeamRatingBySeasonDto.Parameter.builder()
+			.seasonName(seasonName)
+			.pageable(pageable)
+			.build();
+
+		FindTeamRatingBySeasonDto.Response data = aboutLckTeamService.findTeamRatingBySeason(parameter);
+		return ApiResponse.createSuccess(data);
+	}
+
+	@GetMapping("/{teamId}/winning-history")
+	public ApiResponse<FindTeamWinningHistoryDto.Response> findTeamWinningHistory(
+		@PathVariable("teamId") Long teamId,
+		Pageable pageable) {
+		FindTeamWinningHistoryDto.Parameter parameter = FindTeamWinningHistoryDto.Parameter.builder()
+			.teamId(teamId)
+			.pageable(pageable)
+			.build();
+
+		FindTeamWinningHistoryDto.Response data = aboutLckTeamService.findTeamWinningHistory(parameter);
+		return ApiResponse.createSuccess(data);
+	}
+
+	@GetMapping("/{teamId}/rating-history")
+	public ApiResponse<FindTeamRatingHistoryDto.Response> findTeamRatingHistory(
+		@PathVariable("teamId") Long teamId,
+		Pageable pageable) {
+		FindTeamRatingHistoryDto.Parameter parameter = FindTeamRatingHistoryDto.Parameter.builder()
+			.teamId(teamId)
+			.pageable(pageable)
+			.build();
+
+		FindTeamRatingHistoryDto.Response data = aboutLckTeamService.findTeamRatingHistory(parameter);
+		return ApiResponse.createSuccess(data);
+	}
+
+	@GetMapping("/{teamId}/player-history")
+	public ApiResponse<FindTeamPlayerHistoryDto.Response> findTeamPlayerHistory(
+		@PathVariable("teamId") Long teamId,
+		Pageable pageable) {
+		FindTeamPlayerHistoryDto.Parameter parameter = FindTeamPlayerHistoryDto.Parameter.builder()
+			.teamId(teamId)
+			.pageable(pageable)
+			.build();
+
+		FindTeamPlayerHistoryDto.Response data = aboutLckTeamService.findTeamPlayerHistory(parameter);
+		return ApiResponse.createSuccess(data);
+	}
+}

--- a/src/main/java/com/lckback/lckforall/aboutlck/converter/FindTeamPlayerHistoryConverter.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/converter/FindTeamPlayerHistoryConverter.java
@@ -6,7 +6,6 @@ import org.springframework.data.domain.Page;
 
 import com.lckback.lckforall.aboutlck.dto.FindTeamPlayerHistoryDto;
 import com.lckback.lckforall.player.model.Player;
-import com.lckback.lckforall.player.model.SeasonTeamPlayer;
 import com.lckback.lckforall.team.model.SeasonTeam;
 
 public class FindTeamPlayerHistoryConverter {
@@ -32,7 +31,7 @@ public class FindTeamPlayerHistoryConverter {
 
 		return FindTeamPlayerHistoryDto.SeasonDetail.builder()
 			.players(playerDetailList)
-			.listSize(playerDetailList.size())
+			.playerDetailSize(playerDetailList.size())
 			.seasonName(seasonTeam.getSeason().getName())
 			.build();
 	}

--- a/src/main/java/com/lckback/lckforall/aboutlck/converter/FindTeamPlayerHistoryConverter.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/converter/FindTeamPlayerHistoryConverter.java
@@ -31,7 +31,7 @@ public class FindTeamPlayerHistoryConverter {
 
 		return FindTeamPlayerHistoryDto.SeasonDetail.builder()
 			.players(playerDetailList)
-			.playerDetailSize(playerDetailList.size())
+			.numberOfPlayerDetail(playerDetailList.size())
 			.seasonName(seasonTeam.getSeason().getName())
 			.build();
 	}

--- a/src/main/java/com/lckback/lckforall/aboutlck/converter/FindTeamPlayerHistoryConverter.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/converter/FindTeamPlayerHistoryConverter.java
@@ -1,0 +1,48 @@
+package com.lckback.lckforall.aboutlck.converter;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import com.lckback.lckforall.aboutlck.dto.FindTeamPlayerHistoryDto;
+import com.lckback.lckforall.player.model.Player;
+import com.lckback.lckforall.player.model.SeasonTeamPlayer;
+import com.lckback.lckforall.team.model.SeasonTeam;
+
+public class FindTeamPlayerHistoryConverter {
+	public static FindTeamPlayerHistoryDto.Response convertToResponse(Page<SeasonTeam> seasonTeams) {
+		return FindTeamPlayerHistoryDto.Response.builder()
+			.seasonDetails(seasonTeams
+				.stream()
+				.map(FindTeamPlayerHistoryConverter::convertToSeasonDetail)
+				.toList())
+			.totalPage(seasonTeams.getTotalPages())
+			.totalElements(seasonTeams.getTotalElements())
+			.isFirst(seasonTeams.isFirst())
+			.isLast(seasonTeams.isLast())
+			.build();
+	}
+
+	private static FindTeamPlayerHistoryDto.SeasonDetail convertToSeasonDetail(SeasonTeam seasonTeam) {
+		List<FindTeamPlayerHistoryDto.PlayerDetail> playerDetailList = seasonTeam
+			.getSeasonTeamPlayers()
+			.stream()
+			.map(seasonTeamPlayer -> convertToPlayerDetail(seasonTeamPlayer.getPlayer()))
+			.toList();
+
+		return FindTeamPlayerHistoryDto.SeasonDetail.builder()
+			.players(playerDetailList)
+			.listSize(playerDetailList.size())
+			.seasonName(seasonTeam.getSeason().getName())
+			.build();
+	}
+
+	private static FindTeamPlayerHistoryDto.PlayerDetail convertToPlayerDetail(Player player) {
+		return FindTeamPlayerHistoryDto.PlayerDetail.builder()
+			.playerId(player.getId())
+			.playerName(player.getName())
+			.playerRole(player.getRole())
+			.playerPosition(player.getPosition())
+			.build();
+	}
+}

--- a/src/main/java/com/lckback/lckforall/aboutlck/converter/FindTeamRatingBySeasonConverter.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/converter/FindTeamRatingBySeasonConverter.java
@@ -1,0 +1,34 @@
+package com.lckback.lckforall.aboutlck.converter;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import com.lckback.lckforall.aboutlck.dto.FindTeamRatingBySeasonDto;
+import com.lckback.lckforall.team.model.SeasonTeam;
+
+public class FindTeamRatingBySeasonConverter {
+
+	public static FindTeamRatingBySeasonDto.Response convertToResponse(Page<SeasonTeam> seasonTeams) {
+		List<FindTeamRatingBySeasonDto.TeamDetail> teamDetailList = seasonTeams.stream()
+			.map(FindTeamRatingBySeasonConverter::convertToTeamDetailList)
+			.toList();
+
+		return FindTeamRatingBySeasonDto.Response.builder()
+			.teamDetailList(teamDetailList)
+			.totalPage(seasonTeams.getTotalPages())
+			.totalElements(seasonTeams.getTotalElements())
+			.isFirst(seasonTeams.isFirst())
+			.isLast(seasonTeams.isLast())
+			.build();
+	}
+
+	private static FindTeamRatingBySeasonDto.TeamDetail convertToTeamDetailList(SeasonTeam seasonTeam) {
+		return FindTeamRatingBySeasonDto.TeamDetail.builder()
+			.teamId(seasonTeam.getTeam().getId())
+			.teamName(seasonTeam.getTeam().getTeamName())
+			.teamLogoUrl(seasonTeam.getTeam().getTeamLogoUrl())
+			.rating(seasonTeam.getRating())
+			.build();
+	}
+}

--- a/src/main/java/com/lckback/lckforall/aboutlck/converter/FindTeamRatingHistoryConverter.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/converter/FindTeamRatingHistoryConverter.java
@@ -1,0 +1,25 @@
+package com.lckback.lckforall.aboutlck.converter;
+
+import org.springframework.data.domain.Page;
+
+import com.lckback.lckforall.aboutlck.dto.FindTeamRatingHistoryDto;
+import com.lckback.lckforall.team.model.SeasonTeam;
+
+public class FindTeamRatingHistoryConverter {
+	public static FindTeamRatingHistoryDto.Response convertToResponse(Page<SeasonTeam> seasonTeams) {
+		return FindTeamRatingHistoryDto.Response.builder()
+			.seasonDetailList(seasonTeams.map(FindTeamRatingHistoryConverter::convertToSeasonDetail).toList())
+			.totalElements(seasonTeams.getTotalElements())
+			.totalPage(seasonTeams.getTotalPages())
+			.isFirst(seasonTeams.isFirst())
+			.isLast(seasonTeams.isLast())
+			.build();
+	}
+
+	public static FindTeamRatingHistoryDto.SeasonDetail convertToSeasonDetail(SeasonTeam seasonTeam) {
+		return FindTeamRatingHistoryDto.SeasonDetail.builder()
+			.seasonName(seasonTeam.getSeason().getName())
+			.rating(seasonTeam.getRating())
+			.build();
+	}
+}

--- a/src/main/java/com/lckback/lckforall/aboutlck/converter/FindTeamWinningHistoryConverter.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/converter/FindTeamWinningHistoryConverter.java
@@ -1,0 +1,19 @@
+package com.lckback.lckforall.aboutlck.converter;
+
+import org.springframework.data.domain.Page;
+
+import com.lckback.lckforall.aboutlck.dto.FindTeamWinningHistoryDto;
+import com.lckback.lckforall.team.model.SeasonTeam;
+
+public class FindTeamWinningHistoryConverter {
+
+	public static FindTeamWinningHistoryDto.Response convertToResponse(Page<SeasonTeam> seasonTeams) {
+		return FindTeamWinningHistoryDto.Response.builder()
+			.seasonNameList(seasonTeams.stream().map(seasonTeam -> seasonTeam.getSeason().getName()).toList())
+			.totalElements(seasonTeams.getTotalElements())
+			.totalPage(seasonTeams.getTotalPages())
+			.isLast(seasonTeams.isLast())
+			.isFirst(seasonTeams.isFirst())
+			.build();
+	}
+}

--- a/src/main/java/com/lckback/lckforall/aboutlck/dto/FindTeamPlayerHistoryDto.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/dto/FindTeamPlayerHistoryDto.java
@@ -1,0 +1,48 @@
+package com.lckback.lckforall.aboutlck.dto;
+
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+
+import com.lckback.lckforall.base.type.PlayerPosition;
+import com.lckback.lckforall.base.type.PlayerRole;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class FindTeamPlayerHistoryDto {
+	@Getter
+	@Builder
+	public static class Parameter {
+		private Pageable pageable;
+		private Long teamId;
+	}
+
+	@Getter
+	@Builder
+	public static class Response {
+		private List<SeasonDetail> seasonDetails;
+		private Integer totalPage;
+		private Long totalElements;
+		private Boolean isFirst;
+		private Boolean isLast;
+	}
+
+	@Getter
+	@Builder
+	public static class SeasonDetail {
+		private List<PlayerDetail> players;
+		private Integer listSize;
+		private String seasonName;
+	}
+
+	@Getter
+	@Builder
+	public static class PlayerDetail {
+		private Long playerId;
+		private String playerName;
+		private PlayerRole playerRole;
+		private PlayerPosition playerPosition;
+	}
+}

--- a/src/main/java/com/lckback/lckforall/aboutlck/dto/FindTeamPlayerHistoryDto.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/dto/FindTeamPlayerHistoryDto.java
@@ -33,7 +33,7 @@ public class FindTeamPlayerHistoryDto {
 	@Builder
 	public static class SeasonDetail {
 		private List<PlayerDetail> players;
-		private Integer playerDetailSize;
+		private Integer numberOfPlayerDetail;
 		private String seasonName;
 	}
 

--- a/src/main/java/com/lckback/lckforall/aboutlck/dto/FindTeamPlayerHistoryDto.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/dto/FindTeamPlayerHistoryDto.java
@@ -33,7 +33,7 @@ public class FindTeamPlayerHistoryDto {
 	@Builder
 	public static class SeasonDetail {
 		private List<PlayerDetail> players;
-		private Integer listSize;
+		private Integer playerDetailSize;
 		private String seasonName;
 	}
 

--- a/src/main/java/com/lckback/lckforall/aboutlck/dto/FindTeamRatingBySeasonDto.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/dto/FindTeamRatingBySeasonDto.java
@@ -1,0 +1,37 @@
+package com.lckback.lckforall.aboutlck.dto;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class FindTeamRatingBySeasonDto {
+
+	@Getter
+	@Builder
+	public static class Parameter {
+		String seasonName;
+		Pageable pageable;
+	}
+
+	@Getter
+	@Builder
+	public static class Response {
+		private List<TeamDetail> teamDetailList;
+		private Integer totalPage;
+		private Long totalElements;
+		private Boolean isFirst;
+		private Boolean isLast;
+	}
+
+	@Getter
+	@Builder
+	public static class TeamDetail {
+		private Long teamId;
+		private String teamName;
+		private String teamLogoUrl;
+		private Integer rating;
+	}
+}

--- a/src/main/java/com/lckback/lckforall/aboutlck/dto/FindTeamRatingHistoryDto.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/dto/FindTeamRatingHistoryDto.java
@@ -1,0 +1,34 @@
+package com.lckback.lckforall.aboutlck.dto;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class FindTeamRatingHistoryDto {
+	@Getter
+	@Builder
+	public static class Parameter {
+		private Long teamId;
+		private Pageable pageable;
+	}
+
+	@Getter
+	@Builder
+	public static class Response {
+		private List<SeasonDetail> seasonDetailList;
+		private Integer totalPage;
+		private Long totalElements;
+		private Boolean isFirst;
+		private Boolean isLast;
+	}
+
+	@Getter
+	@Builder
+	public static class SeasonDetail {
+		private String seasonName;
+		private Integer rating;
+	}
+}

--- a/src/main/java/com/lckback/lckforall/aboutlck/dto/FindTeamWinningHistoryDto.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/dto/FindTeamWinningHistoryDto.java
@@ -1,0 +1,27 @@
+package com.lckback.lckforall.aboutlck.dto;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class FindTeamWinningHistoryDto {
+	@Getter
+	@Builder
+	public static class Parameter {
+		private Long teamId;
+		private Pageable pageable;
+	}
+
+	@Getter
+	@Builder
+	public static class Response {
+		private List<String> seasonNameList;
+		private Integer totalPage;
+		private Long totalElements;
+		private Boolean isFirst;
+		private Boolean isLast;
+	}
+}

--- a/src/main/java/com/lckback/lckforall/aboutlck/repository/SeasonRepository.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/repository/SeasonRepository.java
@@ -1,0 +1,11 @@
+package com.lckback.lckforall.aboutlck.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.lckback.lckforall.team.model.Season;
+
+public interface SeasonRepository extends JpaRepository<Season, Long> {
+	Optional<Season> findByName(String name);
+}

--- a/src/main/java/com/lckback/lckforall/aboutlck/repository/SeasonTeamRepository.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/repository/SeasonTeamRepository.java
@@ -1,0 +1,21 @@
+package com.lckback.lckforall.aboutlck.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.lckback.lckforall.team.model.Season;
+import com.lckback.lckforall.team.model.SeasonTeam;
+import com.lckback.lckforall.team.model.Team;
+
+public interface SeasonTeamRepository extends JpaRepository<SeasonTeam, Long> {
+	@EntityGraph(attributePaths = {"team"})
+	Page<SeasonTeam> findAllBySeasonOrderByRatingAsc(Season season, Pageable pageable);
+
+	@EntityGraph(attributePaths = {"season"})
+	Page<SeasonTeam> findAllByTeamAndRating(Team team, Integer rating, Pageable pageable);
+
+	@EntityGraph(attributePaths = {"season"})
+	Page<SeasonTeam> findAllByTeam(Team team, Pageable pageable);
+}

--- a/src/main/java/com/lckback/lckforall/aboutlck/repository/TeamRepository.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/repository/TeamRepository.java
@@ -1,0 +1,8 @@
+package com.lckback.lckforall.aboutlck.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.lckback.lckforall.team.model.Team;
+
+public interface TeamRepository extends JpaRepository<Team, Long> {
+}

--- a/src/main/java/com/lckback/lckforall/aboutlck/service/AboutLckTeamService.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/service/AboutLckTeamService.java
@@ -1,7 +1,5 @@
 package com.lckback.lckforall.aboutlck.service;
 
-import java.util.List;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -17,12 +15,10 @@ import com.lckback.lckforall.aboutlck.dto.FindTeamRatingHistoryDto;
 import com.lckback.lckforall.aboutlck.dto.FindTeamRatingBySeasonDto;
 import com.lckback.lckforall.aboutlck.dto.FindTeamWinningHistoryDto;
 import com.lckback.lckforall.aboutlck.repository.SeasonRepository;
-import com.lckback.lckforall.aboutlck.repository.SeasonTeamPlayerRepository;
 import com.lckback.lckforall.aboutlck.repository.SeasonTeamRepository;
 import com.lckback.lckforall.aboutlck.repository.TeamRepository;
 import com.lckback.lckforall.base.api.error.CommonErrorCode;
 import com.lckback.lckforall.base.api.exception.RestApiException;
-import com.lckback.lckforall.player.model.SeasonTeamPlayer;
 import com.lckback.lckforall.team.model.Season;
 import com.lckback.lckforall.team.model.SeasonTeam;
 import com.lckback.lckforall.team.model.Team;
@@ -37,7 +33,6 @@ public class AboutLckTeamService {
 	private final TeamRepository teamRepository;
 	private final SeasonRepository seasonRepository;
 	private final SeasonTeamRepository seasonTeamRepository;
-	private final SeasonTeamPlayerRepository seasonTeamPlayerRepository;
 
 	public FindTeamRatingBySeasonDto.Response findTeamRatingBySeason(FindTeamRatingBySeasonDto.Parameter param) {
 		Season season = seasonRepository.findByName(param.getSeasonName())

--- a/src/main/java/com/lckback/lckforall/aboutlck/service/AboutLckTeamService.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/service/AboutLckTeamService.java
@@ -1,0 +1,86 @@
+package com.lckback.lckforall.aboutlck.service;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.lckback.lckforall.aboutlck.converter.FindTeamPlayerHistoryConverter;
+import com.lckback.lckforall.aboutlck.converter.FindTeamRatingBySeasonConverter;
+import com.lckback.lckforall.aboutlck.converter.FindTeamRatingHistoryConverter;
+import com.lckback.lckforall.aboutlck.converter.FindTeamWinningHistoryConverter;
+import com.lckback.lckforall.aboutlck.dto.FindTeamPlayerHistoryDto;
+import com.lckback.lckforall.aboutlck.dto.FindTeamRatingHistoryDto;
+import com.lckback.lckforall.aboutlck.dto.FindTeamRatingBySeasonDto;
+import com.lckback.lckforall.aboutlck.dto.FindTeamWinningHistoryDto;
+import com.lckback.lckforall.aboutlck.repository.SeasonRepository;
+import com.lckback.lckforall.aboutlck.repository.SeasonTeamPlayerRepository;
+import com.lckback.lckforall.aboutlck.repository.SeasonTeamRepository;
+import com.lckback.lckforall.aboutlck.repository.TeamRepository;
+import com.lckback.lckforall.base.api.error.CommonErrorCode;
+import com.lckback.lckforall.base.api.exception.RestApiException;
+import com.lckback.lckforall.player.model.SeasonTeamPlayer;
+import com.lckback.lckforall.team.model.Season;
+import com.lckback.lckforall.team.model.SeasonTeam;
+import com.lckback.lckforall.team.model.Team;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class AboutLckTeamService {
+
+	private final TeamRepository teamRepository;
+	private final SeasonRepository seasonRepository;
+	private final SeasonTeamRepository seasonTeamRepository;
+	private final SeasonTeamPlayerRepository seasonTeamPlayerRepository;
+
+	public FindTeamRatingBySeasonDto.Response findTeamRatingBySeason(FindTeamRatingBySeasonDto.Parameter param) {
+		Season season = seasonRepository.findByName(param.getSeasonName())
+			.orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+
+		Page<SeasonTeam> seasonTeamList = seasonTeamRepository.findAllBySeasonOrderByRatingAsc(season,
+			param.getPageable());
+
+		return FindTeamRatingBySeasonConverter.convertToResponse(seasonTeamList);
+	}
+
+	public FindTeamWinningHistoryDto.Response findTeamWinningHistory(FindTeamWinningHistoryDto.Parameter param) {
+		Team team = teamRepository.findById(param.getTeamId())
+			.orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+
+		PageRequest pageRequest = PageRequest.of(param.getPageable().getPageNumber(), param.getPageable().getPageSize(),
+			Sort.by("season.name").descending());
+
+		Page<SeasonTeam> seasonTeams = seasonTeamRepository.findAllByTeamAndRating(team, 1,
+			pageRequest);
+
+		return FindTeamWinningHistoryConverter.convertToResponse(seasonTeams);
+	}
+
+	public FindTeamRatingHistoryDto.Response findTeamRatingHistory(FindTeamRatingHistoryDto.Parameter param) {
+		Team team = teamRepository.findById(param.getTeamId())
+			.orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+
+		PageRequest pageRequest = PageRequest.of(param.getPageable().getPageNumber(), param.getPageable().getPageSize(),
+			Sort.by("season.name").descending());
+		Page<SeasonTeam> seasonTeams = seasonTeamRepository.findAllByTeam(team, pageRequest);
+
+		return FindTeamRatingHistoryConverter.convertToResponse(seasonTeams);
+	}
+
+	public FindTeamPlayerHistoryDto.Response findTeamPlayerHistory(FindTeamPlayerHistoryDto.Parameter param) {
+		Team team = teamRepository.findById(param.getTeamId())
+			.orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+
+		PageRequest pageRequest = PageRequest.of(param.getPageable().getPageNumber(), param.getPageable().getPageSize(),
+			Sort.by("season.name").descending());
+		Page<SeasonTeam> seasonTeams = seasonTeamRepository.findAllByTeam(team, pageRequest);
+
+		return FindTeamPlayerHistoryConverter.convertToResponse(seasonTeams);
+	}
+}

--- a/src/main/java/com/lckback/lckforall/aboutlck/service/AboutLckTeamService.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/service/AboutLckTeamService.java
@@ -34,6 +34,7 @@ public class AboutLckTeamService {
 	private final SeasonRepository seasonRepository;
 	private final SeasonTeamRepository seasonTeamRepository;
 
+	// 에러코드 구체화 필요
 	public FindTeamRatingBySeasonDto.Response findTeamRatingBySeason(FindTeamRatingBySeasonDto.Parameter param) {
 		Season season = seasonRepository.findByName(param.getSeasonName())
 			.orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
@@ -44,6 +45,7 @@ public class AboutLckTeamService {
 		return FindTeamRatingBySeasonConverter.convertToResponse(seasonTeamList);
 	}
 
+	// 에러코드 구체화 필요
 	public FindTeamWinningHistoryDto.Response findTeamWinningHistory(FindTeamWinningHistoryDto.Parameter param) {
 		Team team = teamRepository.findById(param.getTeamId())
 			.orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
@@ -57,6 +59,7 @@ public class AboutLckTeamService {
 		return FindTeamWinningHistoryConverter.convertToResponse(seasonTeams);
 	}
 
+	// 에러코드 구체화 필요
 	public FindTeamRatingHistoryDto.Response findTeamRatingHistory(FindTeamRatingHistoryDto.Parameter param) {
 		Team team = teamRepository.findById(param.getTeamId())
 			.orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
@@ -68,6 +71,7 @@ public class AboutLckTeamService {
 		return FindTeamRatingHistoryConverter.convertToResponse(seasonTeams);
 	}
 
+	// 에러코드 구체화 필요
 	public FindTeamPlayerHistoryDto.Response findTeamPlayerHistory(FindTeamPlayerHistoryDto.Parameter param) {
 		Team team = teamRepository.findById(param.getTeamId())
 			.orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));

--- a/src/main/java/com/lckback/lckforall/aboutlck/service/AboutLckTeamService.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/service/AboutLckTeamService.java
@@ -2,6 +2,7 @@ package com.lckback.lckforall.aboutlck.service;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,7 +35,6 @@ public class AboutLckTeamService {
 	private final SeasonRepository seasonRepository;
 	private final SeasonTeamRepository seasonTeamRepository;
 
-	// 에러코드 구체화 필요
 	public FindTeamRatingBySeasonDto.Response findTeamRatingBySeason(FindTeamRatingBySeasonDto.Parameter param) {
 		Season season = seasonRepository.findByName(param.getSeasonName())
 			.orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
@@ -45,13 +45,11 @@ public class AboutLckTeamService {
 		return FindTeamRatingBySeasonConverter.convertToResponse(seasonTeamList);
 	}
 
-	// 에러코드 구체화 필요
-	public FindTeamWinningHistoryDto.Response findTeamWinningHistory(FindTeamWinningHistoryDto.Parameter param) {
-		Team team = teamRepository.findById(param.getTeamId())
-			.orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
 
-		PageRequest pageRequest = PageRequest.of(param.getPageable().getPageNumber(), param.getPageable().getPageSize(),
-			Sort.by("season.name").descending());
+	public FindTeamWinningHistoryDto.Response findTeamWinningHistory(FindTeamWinningHistoryDto.Parameter param) {
+		Team team = findTeamByTeamId(param.getTeamId());
+
+		PageRequest pageRequest = createPageRequestSortBySeasonName(param.getPageable());
 
 		Page<SeasonTeam> seasonTeams = seasonTeamRepository.findAllByTeamAndRating(team, 1,
 			pageRequest);
@@ -59,27 +57,31 @@ public class AboutLckTeamService {
 		return FindTeamWinningHistoryConverter.convertToResponse(seasonTeams);
 	}
 
-	// 에러코드 구체화 필요
 	public FindTeamRatingHistoryDto.Response findTeamRatingHistory(FindTeamRatingHistoryDto.Parameter param) {
-		Team team = teamRepository.findById(param.getTeamId())
-			.orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+		Team team = findTeamByTeamId(param.getTeamId());
 
-		PageRequest pageRequest = PageRequest.of(param.getPageable().getPageNumber(), param.getPageable().getPageSize(),
-			Sort.by("season.name").descending());
+		PageRequest pageRequest = createPageRequestSortBySeasonName(param.getPageable());
 		Page<SeasonTeam> seasonTeams = seasonTeamRepository.findAllByTeam(team, pageRequest);
 
 		return FindTeamRatingHistoryConverter.convertToResponse(seasonTeams);
 	}
 
-	// 에러코드 구체화 필요
 	public FindTeamPlayerHistoryDto.Response findTeamPlayerHistory(FindTeamPlayerHistoryDto.Parameter param) {
-		Team team = teamRepository.findById(param.getTeamId())
-			.orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+		Team team = findTeamByTeamId(param.getTeamId());
 
-		PageRequest pageRequest = PageRequest.of(param.getPageable().getPageNumber(), param.getPageable().getPageSize(),
-			Sort.by("season.name").descending());
+		PageRequest pageRequest = createPageRequestSortBySeasonName(param.getPageable());
 		Page<SeasonTeam> seasonTeams = seasonTeamRepository.findAllByTeam(team, pageRequest);
 
 		return FindTeamPlayerHistoryConverter.convertToResponse(seasonTeams);
+	}
+
+	// 에러코드 구체화 필요
+	private Team findTeamByTeamId(Long teamId) {
+		return teamRepository.findById(teamId)
+			.orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+	}
+
+	private PageRequest createPageRequestSortBySeasonName(Pageable pageable) {
+		return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), Sort.by("season.name").descending());
 	}
 }


### PR DESCRIPTION
## 개요
team 정보를 반환하는 api 구현
## 작업사항
1. 특정시즌(아마 현재시즌)의 팀 랭킹 조회 api
2. 특정 팀의 우승기록 조회 api
3. 특정 팀의 최근 시즌별 리그 순위 조회 api
4. 특정 팀의 최근 시즌별 선수 조회 api
## 변경로직
매치 조회 컨트롤러에 requestmapping 추가
### 변경 전

### 변경 후

## 사용방법
팀 정보 조회 api는 pageable과 필요한 정보 (시즌 이름, 팀 id)를 받음
## 기타