### PR TITLE
[Feat/#49] 뷰잉파티 상세 조회 API 구현, ViewingParty Entity 수정

### DIFF
--- a/src/main/java/com/lckback/lckforall/base/api/error/CommonErrorCode.java
+++ b/src/main/java/com/lckback/lckforall/base/api/error/CommonErrorCode.java
@@ -14,6 +14,9 @@ public enum CommonErrorCode implements ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않는 HTTP Method입니다."),
 
+    // 사용자 관련
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을수 없습니다."),
+
     // 뷰잉파티 관련
     PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "뷰잉파티를 찾을수 없습니다.");
 

--- a/src/main/java/com/lckback/lckforall/viewing/controller/ViewingController.java
+++ b/src/main/java/com/lckback/lckforall/viewing/controller/ViewingController.java
@@ -1,15 +1,14 @@
 package com.lckback.lckforall.viewing.controller;
 
 import com.lckback.lckforall.base.api.ApiResponse;
-import com.lckback.lckforall.viewing.converter.ViewingPartyConverter;
-import com.lckback.lckforall.viewing.model.ViewingParty;
+import com.lckback.lckforall.viewing.dto.GetViewingPartyDetailDTO;
+import com.lckback.lckforall.viewing.dto.ViewingPartyListDTO;
 import com.lckback.lckforall.viewing.service.ViewingPartyService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -50,9 +49,25 @@ public class ViewingController {
             @Parameter(name = "page", description = "query string(RequestParam) - 몇번째 페이지인지 가리키는 page 변수 (0부터 시작)"),
             @Parameter(name = "size", description = "query string(RequestParam) - 몇 개씩 불러올지 개수를 세는 변수 (1 이상 자연수로 설정)")
     })
-    public ApiResponse<?> getViewingPartyList(@RequestHeader(name = "user_id") Long userId,
-                                              @RequestParam(name = "page") Integer page,
-                                              @RequestParam(name = "size") Integer size){
+    public ApiResponse<ViewingPartyListDTO.ResponseList> getViewingPartyList(@RequestHeader(name = "user_id") Long userId,
+                                                                @RequestParam(name = "page") Integer page,
+                                                                @RequestParam(name = "size") Integer size){
         return ApiResponse.createSuccess(viewingPartyService.getViewingPartyList(userId, page, size));
+    }
+
+    @GetMapping("/{viewing_party_id}/detail")
+    @Operation(summary = "뷰잉파티 상세 조회 API", description = "뷰잉파티 글을 상세 조회하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "VIEWING4001", description = "NOT_FOUND, 뷰잉파티글을 찾을 수 없습니다."),
+
+    })
+    @Parameters({
+            @Parameter(name = "user_id", description = "RequestHeader - 로그인한 사용자 아이디(accessToken으로 변경 예정)"),
+            @Parameter(name = "viewing_party_id", description = "query string(RequestParam) - 해당 뷰잉파티 글의 ID"),
+    })
+    public ApiResponse<GetViewingPartyDetailDTO.Response> getViewingPartyList(@RequestHeader(name = "user_id") Long userId,
+                                                                     @RequestParam(name = "viewing_party_id") Long viewingId){
+        return ApiResponse.createSuccess(viewingPartyService.getViewingPartyDetail(userId, viewingId));
     }
 }

--- a/src/main/java/com/lckback/lckforall/viewing/converter/ViewingPartyConverter.java
+++ b/src/main/java/com/lckback/lckforall/viewing/converter/ViewingPartyConverter.java
@@ -1,5 +1,6 @@
 package com.lckback.lckforall.viewing.converter;
 
+import com.lckback.lckforall.viewing.dto.GetViewingPartyDetailDTO;
 import com.lckback.lckforall.viewing.dto.ViewingPartyListDTO;
 import com.lckback.lckforall.viewing.model.ViewingParty;
 import org.springframework.data.domain.Page;
@@ -25,6 +26,21 @@ public class ViewingPartyConverter {
                 .latitude(viewingParty.getLatitude())
                 .longitude(viewingParty.getLongitude())
                 .location(viewingParty.getLocation())
+                .build();
+    }
+    public static GetViewingPartyDetailDTO.Response toResponse(ViewingParty viewingParty) {
+        return GetViewingPartyDetailDTO.Response.builder()
+                .name(viewingParty.getName())
+                .ownerName(viewingParty.getUser().getNickname())
+                .ownerTeam(viewingParty.getUser().getTeam().getTeamName())
+                .ownerImage(viewingParty.getUser().getProfileImageUrl())
+                .qualify(viewingParty.getPartyQualify())
+                .partyDate(viewingParty.getDate())
+                .location(viewingParty.getLocation())
+                .price(viewingParty.getPrice())
+                .lowParticipate(viewingParty.getLowParticipate())
+                .highParticipate(viewingParty.getHighParticipate())
+                .etc(viewingParty.getEtc())
                 .build();
     }
 }

--- a/src/main/java/com/lckback/lckforall/viewing/dto/GetViewingPartyDetailDTO.java
+++ b/src/main/java/com/lckback/lckforall/viewing/dto/GetViewingPartyDetailDTO.java
@@ -1,0 +1,28 @@
+package com.lckback.lckforall.viewing.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class GetViewingPartyDetailDTO {
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Response {
+        String name;
+        String ownerName;
+        String ownerTeam;
+        String ownerImage;
+        String qualify;
+        LocalDateTime partyDate;
+        String location;
+        Integer price;
+        Integer lowParticipate;
+        Integer highParticipate;
+        String etc;
+    }
+}

--- a/src/main/java/com/lckback/lckforall/viewing/model/ViewingParty.java
+++ b/src/main/java/com/lckback/lckforall/viewing/model/ViewingParty.java
@@ -51,7 +51,10 @@ public class ViewingParty extends BaseEntity {
 	private Integer price;
 
 	@Column(nullable = false)
-	private Integer limitParticipate;
+	private Integer lowParticipate;
+
+	@Column(nullable = false)
+	private Integer highParticipate;
 
 	@Column(nullable = false, length = 100)
 	private String partyQualify;

--- a/src/main/java/com/lckback/lckforall/viewing/service/ViewingPartyService.java
+++ b/src/main/java/com/lckback/lckforall/viewing/service/ViewingPartyService.java
@@ -1,7 +1,10 @@
 package com.lckback.lckforall.viewing.service;
 
+import com.lckback.lckforall.viewing.dto.GetViewingPartyDetailDTO;
 import com.lckback.lckforall.viewing.dto.ViewingPartyListDTO;
 
 public interface ViewingPartyService {
     ViewingPartyListDTO.ResponseList getViewingPartyList(Long userId, Integer page, Integer size);
+
+    GetViewingPartyDetailDTO.Response getViewingPartyDetail(Long userId, Long viewingId);
 }

--- a/src/main/java/com/lckback/lckforall/viewing/service/ViewingPartyServiceImpl.java
+++ b/src/main/java/com/lckback/lckforall/viewing/service/ViewingPartyServiceImpl.java
@@ -4,6 +4,7 @@ import com.lckback.lckforall.base.api.error.CommonErrorCode;
 import com.lckback.lckforall.user.model.User;
 import com.lckback.lckforall.user.respository.UserRepository;
 import com.lckback.lckforall.viewing.converter.ViewingPartyConverter;
+import com.lckback.lckforall.viewing.dto.GetViewingPartyDetailDTO;
 import com.lckback.lckforall.viewing.dto.ViewingPartyListDTO;
 import com.lckback.lckforall.viewing.model.ViewingParty;
 import com.lckback.lckforall.viewing.repository.ViewingPartyRepository;
@@ -21,8 +22,17 @@ public class ViewingPartyServiceImpl implements ViewingPartyService {
     @Override
     @Transactional(readOnly = true)
     public ViewingPartyListDTO.ResponseList getViewingPartyList(Long userId, Integer page, Integer size) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException(CommonErrorCode.PARTY_NOT_FOUND.getMessage()));
+        User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException(CommonErrorCode.USER_NOT_FOUND.getMessage()));
         Page<ViewingParty> viewingPartyList = viewingPartyRepository.findAllByOrderByCreatedAtDesc(PageRequest.of(page, size));
         return ViewingPartyConverter.toPartyListRes(viewingPartyList);
+    }
+
+    @Override
+    @Transactional
+    public GetViewingPartyDetailDTO.Response getViewingPartyDetail(Long userId, Long viewingId) {
+        userRepository.findById(userId).orElseThrow(() -> new RuntimeException(CommonErrorCode.USER_NOT_FOUND.getMessage()));
+        ViewingParty viewingPartyDetail = viewingPartyRepository.findById(viewingId).orElseThrow(() -> new RuntimeException(CommonErrorCode.PARTY_NOT_FOUND.getMessage()));
+        return ViewingPartyConverter.toResponse(viewingPartyDetail);
+
     }
 }


### PR DESCRIPTION
## 개요
뷰잉파티 상세 조회 API 구현, ViewingParty Entity 수정
## 작업사항

1. 뷰잉 파티 글 상세 조회 API 구현
2. 파티 참여 최소 인원 / 최대 인원 칼럼 추가

## 변경로직

### 변경 전
Integer limit
### 변경 후
Integer lowParticipate, Integer highParticipate

## 사용방법
https://www.notion.so/API-38e4db9c86b644a7b1b4bcf183551a84?p=b2ae6d566dca4b6396d254a33eb20609&pm=s
## 기타