### PR TITLE
[Feat/#57] : 뷰잉파티 개최 API 구현

### DIFF
--- a/src/main/java/com/lckback/lckforall/viewing/controller/ViewingChangeController.java
+++ b/src/main/java/com/lckback/lckforall/viewing/controller/ViewingChangeController.java
@@ -1,0 +1,35 @@
+package com.lckback.lckforall.viewing.controller;
+
+import com.lckback.lckforall.base.api.ApiResponse;
+import com.lckback.lckforall.viewing.dto.ChangeViewingPartyDTO;
+import com.lckback.lckforall.viewing.service.ViewingPartyChangeServiceImpl;
+import com.lckback.lckforall.viewing.service.ViewingPartyService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/viewing")
+public class ViewingChangeController {
+
+    private final ViewingPartyChangeServiceImpl viewingPartyChangeService;
+    @PostMapping("/create")
+    @Operation(summary = "뷰잉파티 개최 API", description = "뷰잉파티를 개최하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "VIEWING4003", description = "NOT_FOUND, 뷰잉파티 글 생성에 실패했습니다."),
+
+    })
+    @Parameters({
+            @Parameter(name = "user_id", description = "RequestHeader - 로그인한 사용자 아이디(accessToken으로 변경 예정)"),
+    })
+    public ApiResponse<?> createViewingParty(@RequestHeader(name = "user_id") Long userId,
+                                             @RequestBody @Valid ChangeViewingPartyDTO.CreateViewingPartyRequest request){
+        return ApiResponse.createSuccess(viewingPartyChangeService.createViewingParty(userId, request));
+    }
+}

--- a/src/main/java/com/lckback/lckforall/viewing/converter/ViewingPartyChangeConverter.java
+++ b/src/main/java/com/lckback/lckforall/viewing/converter/ViewingPartyChangeConverter.java
@@ -1,0 +1,27 @@
+package com.lckback.lckforall.viewing.converter;
+
+import com.lckback.lckforall.user.model.User;
+import com.lckback.lckforall.viewing.dto.ChangeViewingPartyDTO;
+import com.lckback.lckforall.viewing.model.ViewingParty;
+
+public class ViewingPartyChangeConverter {
+    public static ViewingParty toViewingParty(ChangeViewingPartyDTO.CreateViewingPartyRequest createViewingPartyRequest){
+        return ViewingParty.builder()
+                .name(createViewingPartyRequest.getName())
+                .date(createViewingPartyRequest.getDate())
+                .latitude(createViewingPartyRequest.getLatitude())
+                .longitude(createViewingPartyRequest.getLongitude())
+                .price(createViewingPartyRequest.getPrice())
+                .lowParticipate(createViewingPartyRequest.getLowParticipate())
+                .highParticipate(createViewingPartyRequest.getHighParticipate())
+                .partyQualify(createViewingPartyRequest.getQualify())
+                .etc(createViewingPartyRequest.getEtc())
+                .build();
+    }
+    public static ChangeViewingPartyDTO.Response toResponse(ViewingParty viewingParty){
+        return ChangeViewingPartyDTO.Response.builder()
+                .userId(viewingParty.getUser().getId())
+                .viewingPartyId(viewingParty.getId())
+                .build();
+    }
+}

--- a/src/main/java/com/lckback/lckforall/viewing/dto/ChangeViewingPartyDTO.java
+++ b/src/main/java/com/lckback/lckforall/viewing/dto/ChangeViewingPartyDTO.java
@@ -1,0 +1,46 @@
+package com.lckback.lckforall.viewing.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class ChangeViewingPartyDTO {
+
+    @Getter
+    public static class CreateViewingPartyRequest {
+        @NotBlank(message = "이름을 생략할수 없습니다.")
+        @Size(min = 1, max = 20, message = "이름은 1자이상 20자이하여야 합니다.")
+        String name;
+        LocalDateTime date;
+        @NotNull(message = "장소를 생략할수 없습니다.")
+        Double latitude;
+        @NotNull(message = "장소를 생략할수 없습니다.")
+        Double longitude;
+        @NotBlank(message = "비용을 생략할수 없습니다.")
+        Integer price;
+        @NotBlank(message = "최소인원을 생략할수 없습니다.")
+        Integer lowParticipate;
+        @NotBlank(message = "최대인원을 생략할수 없습니다.")
+        Integer highParticipate;
+        @NotBlank(message = "참여자격 및 조건을 생략할수 없습니다.")
+        @Size(min = 1, max = 100, message = "참여자격 및 조건은 1자이상 100자이하여야 합니다.")
+        String qualify;
+        @Size(min = 0, max = 1000, message = "기타 메세지는 최대 1000자까지 작성할수 있습니다.")
+        String etc;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Response{
+        Long userId;
+        Long viewingPartyId;
+    }
+}

--- a/src/main/java/com/lckback/lckforall/viewing/model/ViewingParty.java
+++ b/src/main/java/com/lckback/lckforall/viewing/model/ViewingParty.java
@@ -71,4 +71,12 @@ public class ViewingParty extends BaseEntity {
 
 	@OneToMany(mappedBy = "viewingParty")
 	private List<Participate> participates = new ArrayList<>();
+
+	public void setUser(User user) {
+		if(this.user != null) {
+			user.getHostingViewingParties().remove(this);
+		}
+		this.user = user;
+		user.getHostingViewingParties().add(this);
+	}
 }

--- a/src/main/java/com/lckback/lckforall/viewing/service/ViewingPartyChangeService.java
+++ b/src/main/java/com/lckback/lckforall/viewing/service/ViewingPartyChangeService.java
@@ -1,0 +1,9 @@
+package com.lckback.lckforall.viewing.service;
+
+import com.lckback.lckforall.viewing.dto.ChangeViewingPartyDTO;
+
+public interface ViewingPartyChangeService {
+
+    ChangeViewingPartyDTO.Response createViewingParty(Long userId, ChangeViewingPartyDTO.CreateViewingPartyRequest request);
+
+}

--- a/src/main/java/com/lckback/lckforall/viewing/service/ViewingPartyChangeServiceImpl.java
+++ b/src/main/java/com/lckback/lckforall/viewing/service/ViewingPartyChangeServiceImpl.java
@@ -1,0 +1,32 @@
+package com.lckback.lckforall.viewing.service;
+
+import com.lckback.lckforall.base.api.error.CommonErrorCode;
+import com.lckback.lckforall.base.api.exception.RestApiException;
+import com.lckback.lckforall.user.model.User;
+import com.lckback.lckforall.user.respository.UserRepository;
+import com.lckback.lckforall.viewing.converter.ViewingPartyChangeConverter;
+import com.lckback.lckforall.viewing.dto.ChangeViewingPartyDTO;
+import com.lckback.lckforall.viewing.model.ViewingParty;
+import com.lckback.lckforall.viewing.repository.ViewingPartyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ViewingPartyChangeServiceImpl implements ViewingPartyChangeService {
+
+    private final UserRepository userRepository;
+    private final ViewingPartyRepository viewingPartyRepository;
+
+
+    @Override
+    @Transactional
+    public ChangeViewingPartyDTO.Response createViewingParty(Long userId, ChangeViewingPartyDTO.CreateViewingPartyRequest request) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(CommonErrorCode.USER_NOT_FOUND));
+        ViewingParty viewingParty = ViewingPartyChangeConverter.toViewingParty(request);
+        viewingParty.setUser(user);
+        ViewingParty save = viewingPartyRepository.save(viewingParty);
+        return ViewingPartyChangeConverter.toResponse(save);
+    }
+}


### PR DESCRIPTION
## 개요
뷰잉파티 개최 API 구혅
## 작업사항
figma에 정의된 User Request의 제약사항을 @Valid 어노테이션으로 검증했습니다. 추후 커스텀 어노테이션으로 검증로직을 변경할 예정입니다.
## 변경로직

### 변경 전

### 변경 후

## 사용방법
https://www.notion.so/API-38e4db9c86b644a7b1b4bcf183551a84?p=a3637962e8d6409b8b1d80fc345f950d&pm=s
## 기타