### PR TITLE
[Feat/#66] about lck player information by team

### DIFF
--- a/src/main/java/com/lckback/lckforall/aboutlck/controller/AboutLckTeamController.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/controller/AboutLckTeamController.java
@@ -8,11 +8,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.lckback.lckforall.aboutlck.dto.team.FindTeamPlayerHistoryDto;
+import com.lckback.lckforall.aboutlck.dto.team.FindTeamPlayerInformationDto;
 import com.lckback.lckforall.aboutlck.dto.team.FindTeamRatingHistoryDto;
 import com.lckback.lckforall.aboutlck.dto.team.FindTeamRatingBySeasonDto;
 import com.lckback.lckforall.aboutlck.dto.team.FindTeamWinningHistoryDto;
 import com.lckback.lckforall.aboutlck.service.AboutLckTeamService;
 import com.lckback.lckforall.base.api.ApiResponse;
+import com.lckback.lckforall.base.type.PlayerRole;
 
 import lombok.RequiredArgsConstructor;
 
@@ -72,6 +74,22 @@ public class AboutLckTeamController {
 			.build();
 
 		FindTeamPlayerHistoryDto.Response data = aboutLckTeamService.findTeamPlayerHistory(parameter);
+		return ApiResponse.createSuccess(data);
+	}
+
+	@GetMapping("/{teamId}/player-information")
+	public ApiResponse<FindTeamPlayerInformationDto.Response> findTeamPlayerInformationBySeasonAndRole(
+		@PathVariable("teamId") Long teamId,
+		@RequestParam("seasonName") String seasonName,
+		@RequestParam("player_role") PlayerRole role) {
+		FindTeamPlayerInformationDto.Parameter parameter = FindTeamPlayerInformationDto.Parameter.builder()
+			.teamId(teamId)
+			.seasonName(seasonName)
+			.playerRole(role)
+			.build();
+
+		FindTeamPlayerInformationDto.Response data = aboutLckTeamService.findTeamPlayerInformation(
+			parameter);
 		return ApiResponse.createSuccess(data);
 	}
 }

--- a/src/main/java/com/lckback/lckforall/aboutlck/converter/team/FindTeamPlayerInformationConverter.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/converter/team/FindTeamPlayerInformationConverter.java
@@ -1,0 +1,29 @@
+package com.lckback.lckforall.aboutlck.converter.team;
+
+import java.util.List;
+
+import com.lckback.lckforall.aboutlck.dto.team.FindTeamPlayerInformationDto;
+import com.lckback.lckforall.player.model.Player;
+
+public class FindTeamPlayerInformationConverter {
+
+	public static FindTeamPlayerInformationDto.Response convertToResponse(List<Player> players) {
+		List<FindTeamPlayerInformationDto.PlayerDetail> playerDetails = players.stream()
+			.map(FindTeamPlayerInformationConverter::convertToPlayerDetail)
+			.toList();
+
+		return FindTeamPlayerInformationDto.Response.builder()
+			.playerDetails(playerDetails)
+			.numberOfPlayerDetails(playerDetails.size())
+			.build();
+	}
+
+	private static FindTeamPlayerInformationDto.PlayerDetail convertToPlayerDetail(Player player) {
+		return FindTeamPlayerInformationDto.PlayerDetail.builder()
+			.playerId(player.getId())
+			.playerName(player.getName())
+			.playerRole(player.getRole())
+			.profileImageUrl(player.getProfileImageUrl())
+			.build();
+	}
+}

--- a/src/main/java/com/lckback/lckforall/aboutlck/dto/team/FindTeamPlayerInformationDto.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/dto/team/FindTeamPlayerInformationDto.java
@@ -1,0 +1,34 @@
+package com.lckback.lckforall.aboutlck.dto.team;
+
+import java.util.List;
+
+import com.lckback.lckforall.base.type.PlayerRole;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class FindTeamPlayerInformationDto {
+	@Getter
+	@Builder
+	public static class Parameter {
+		private Long teamId;
+		private String seasonName;
+		private PlayerRole playerRole;
+	}
+
+	@Getter
+	@Builder
+	public static class Response {
+		private List<PlayerDetail> playerDetails;
+		private Integer numberOfPlayerDetails;
+	}
+
+	@Getter
+	@Builder
+	public static class PlayerDetail {
+		private Long playerId;
+		private String playerName;
+		private PlayerRole playerRole;
+		private String profileImageUrl;
+	}
+}

--- a/src/main/java/com/lckback/lckforall/aboutlck/service/AboutLckTeamService.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/service/AboutLckTeamService.java
@@ -1,5 +1,7 @@
 package com.lckback.lckforall.aboutlck.service;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -8,13 +10,18 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.lckback.lckforall.aboutlck.converter.team.FindTeamPlayerHistoryConverter;
+import com.lckback.lckforall.aboutlck.converter.team.FindTeamPlayerInformationConverter;
 import com.lckback.lckforall.aboutlck.converter.team.FindTeamRatingBySeasonConverter;
 import com.lckback.lckforall.aboutlck.converter.team.FindTeamRatingHistoryConverter;
 import com.lckback.lckforall.aboutlck.converter.team.FindTeamWinningHistoryConverter;
 import com.lckback.lckforall.aboutlck.dto.team.FindTeamPlayerHistoryDto;
+import com.lckback.lckforall.aboutlck.dto.team.FindTeamPlayerInformationDto;
 import com.lckback.lckforall.aboutlck.dto.team.FindTeamRatingHistoryDto;
 import com.lckback.lckforall.aboutlck.dto.team.FindTeamRatingBySeasonDto;
 import com.lckback.lckforall.aboutlck.dto.team.FindTeamWinningHistoryDto;
+import com.lckback.lckforall.player.model.Player;
+import com.lckback.lckforall.player.model.SeasonTeamPlayer;
+import com.lckback.lckforall.player.repository.SeasonTeamPlayerRepository;
 import com.lckback.lckforall.team.repository.SeasonRepository;
 import com.lckback.lckforall.team.repository.SeasonTeamRepository;
 import com.lckback.lckforall.team.repository.TeamRepository;
@@ -34,6 +41,7 @@ public class AboutLckTeamService {
 	private final TeamRepository teamRepository;
 	private final SeasonRepository seasonRepository;
 	private final SeasonTeamRepository seasonTeamRepository;
+	private final SeasonTeamPlayerRepository seasonTeamPlayerRepository;
 
 	public FindTeamRatingBySeasonDto.Response findTeamRatingBySeason(FindTeamRatingBySeasonDto.Parameter param) {
 		Season season = seasonRepository.findByName(param.getSeasonName())
@@ -44,7 +52,6 @@ public class AboutLckTeamService {
 
 		return FindTeamRatingBySeasonConverter.convertToResponse(seasonTeamList);
 	}
-
 
 	public FindTeamWinningHistoryDto.Response findTeamWinningHistory(FindTeamWinningHistoryDto.Parameter param) {
 		Team team = findTeamByTeamId(param.getTeamId());
@@ -75,9 +82,32 @@ public class AboutLckTeamService {
 		return FindTeamPlayerHistoryConverter.convertToResponse(seasonTeams);
 	}
 
+	public FindTeamPlayerInformationDto.Response findTeamPlayerInformation(
+		FindTeamPlayerInformationDto.Parameter param) {
+		Team team = findTeamByTeamId(param.getTeamId());
+		Season season = findSeasonBySeasonName(param.getSeasonName());
+
+		SeasonTeam seasonTeam = seasonTeamRepository.findBySeasonAndTeam(season, team)
+			.orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+
+		List<SeasonTeamPlayer> seasonTeamPlayers = seasonTeamPlayerRepository.findAllBySeasonTeam(seasonTeam);
+		List<Player> players = seasonTeamPlayers.stream()
+			.map(SeasonTeamPlayer::getPlayer)
+			.filter(player -> player.getRole().equals(param.getPlayerRole()))
+			.toList();
+
+		return FindTeamPlayerInformationConverter.convertToResponse(players);
+	}
+
 	// 에러코드 구체화 필요
 	private Team findTeamByTeamId(Long teamId) {
 		return teamRepository.findById(teamId)
+			.orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+	}
+
+	// 에러코드 구체화 필요
+	private Season findSeasonBySeasonName(String seasonName) {
+		return seasonRepository.findByName(seasonName)
 			.orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
 	}
 

--- a/src/main/java/com/lckback/lckforall/player/repository/SeasonTeamPlayerRepository.java
+++ b/src/main/java/com/lckback/lckforall/player/repository/SeasonTeamPlayerRepository.java
@@ -7,8 +7,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.lckback.lckforall.player.model.Player;
 import com.lckback.lckforall.player.model.SeasonTeamPlayer;
+import com.lckback.lckforall.team.model.SeasonTeam;
 
 public interface SeasonTeamPlayerRepository extends JpaRepository<SeasonTeamPlayer, Long> {
 	@EntityGraph(attributePaths = {"seasonTeam"})
 	List<SeasonTeamPlayer> findAllByPlayer(Player player);
+
+	@EntityGraph(attributePaths = {"player"})
+	List<SeasonTeamPlayer> findAllBySeasonTeam(SeasonTeam seasonTeam);
 }

--- a/src/main/java/com/lckback/lckforall/team/repository/SeasonTeamRepository.java
+++ b/src/main/java/com/lckback/lckforall/team/repository/SeasonTeamRepository.java
@@ -1,6 +1,7 @@
 package com.lckback.lckforall.team.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -31,4 +32,6 @@ public interface SeasonTeamRepository extends JpaRepository<SeasonTeam, Long> {
 	@Query("select st from SeasonTeam st join st.seasonTeamPlayers stp where st.rating = 1 and stp in :seasonTeamPlayers")
 	Page<SeasonTeam> findWinningSeasonTeamBySeasonTeamPlayers(List<SeasonTeamPlayer> seasonTeamPlayers,
 		Pageable pageable);
+
+	Optional<SeasonTeam> findBySeasonAndTeam (Season season, Team team);
 }


### PR DESCRIPTION
## 개요
팀의 선수 정보를 조회하는 api
## 작업사항
팀 id (path variable), seasonName, playerRole (request param) 으로 특정 시즌 팀의 특정 역할 선수 제공
## 변경로직

### 변경 전

### 변경 후

## 사용방법
GET /aboutlck/team/{teamId}/player-informaion 으로 요청
path variable : teamId
request param : season name (string) , player role (enum-PlayerRole)
## 기타