### PR TITLE
[Feat/#61] 뷰잉파티 글 수정/삭제 API 구현

### DIFF
--- a/src/main/java/com/lckback/lckforall/base/api/error/ViewingPartyErrorCode.java
+++ b/src/main/java/com/lckback/lckforall/base/api/error/ViewingPartyErrorCode.java
@@ -8,8 +8,9 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ViewingPartyErrorCode implements ErrorCode {
     PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "뷰잉파티를 찾을수 없습니다."),
-    FAILED_PARTICIPATE_PARTY(HttpStatus.NOT_ACCEPTABLE, "뷰잉파티 참여에 실패했습니다.");
-
+    FAILED_PARTICIPATE_PARTY(HttpStatus.NOT_ACCEPTABLE, "뷰잉파티 참여에 실패했습니다."),
+    FAILED_UPDATE_VIEWING_PARTY(HttpStatus.NOT_ACCEPTABLE, "뷰잉파티 글 수정에 실패했습니다."),
+    OWNER_VIEWING_PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "개최자가 생성한 뷰잉파티 글을 찾을수 없습니다.");
     private final HttpStatus httpStatus;
     private final String message;
 

--- a/src/main/java/com/lckback/lckforall/viewing/controller/ViewingChangeController.java
+++ b/src/main/java/com/lckback/lckforall/viewing/controller/ViewingChangeController.java
@@ -3,7 +3,6 @@ package com.lckback.lckforall.viewing.controller;
 import com.lckback.lckforall.base.api.ApiResponse;
 import com.lckback.lckforall.viewing.dto.ChangeViewingPartyDTO;
 import com.lckback.lckforall.viewing.service.ViewingPartyChangeServiceImpl;
-import com.lckback.lckforall.viewing.service.ViewingPartyService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -45,7 +44,7 @@ public class ViewingChangeController {
             @Parameter(name = "user_id", description = "RequestHeader - 로그인한 사용자 아이디(accessToken으로 변경 예정)"),
             @Parameter(name = "viewing_party_id", description = "query string(RequestParam) - 해당 뷰잉파티 글의 ID"),
     })
-    public ApiResponse<?> createViewingParty(@RequestHeader(name = "user_id") Long userId,
+    public ApiResponse<?> updateViewingParty(@RequestHeader(name = "user_id") Long userId,
                                              @RequestParam(name = "viewing_party_id") Long viewingPartyId,
                                              @RequestBody @Valid ChangeViewingPartyDTO.CreateViewingPartyRequest request){
         return ApiResponse.createSuccess(viewingPartyChangeService.updateViewingParty(userId, viewingPartyId, request));
@@ -63,7 +62,7 @@ public class ViewingChangeController {
             @Parameter(name = "user_id", description = "RequestHeader - 로그인한 사용자 아이디(accessToken으로 변경 예정)"),
             @Parameter(name = "viewing_party_id", description = "query string(RequestParam) - 해당 뷰잉파티 글의 ID"),
     })
-    public ApiResponse<?> createViewingParty(@RequestHeader(name = "user_id") Long userId,
+    public ApiResponse<?> deleteViewingParty(@RequestHeader(name = "user_id") Long userId,
                                              @RequestParam(name = "viewing_party_id") Long viewingPartyId){
         return ApiResponse.createSuccess(viewingPartyChangeService.deleteViewingParty(userId, viewingPartyId));
     }

--- a/src/main/java/com/lckback/lckforall/viewing/controller/ViewingChangeController.java
+++ b/src/main/java/com/lckback/lckforall/viewing/controller/ViewingChangeController.java
@@ -32,4 +32,39 @@ public class ViewingChangeController {
                                              @RequestBody @Valid ChangeViewingPartyDTO.CreateViewingPartyRequest request){
         return ApiResponse.createSuccess(viewingPartyChangeService.createViewingParty(userId, request));
     }
+
+    @PatchMapping("/{viewing_party_id}/update")
+    @Operation(summary = "뷰잉파티 수정 API", description = "뷰잉파티 글을 수정하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "VIEWING4003", description = "NOT_ACCEPTABLE, 뷰잉파티 글 수정에 실패했습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "VIEWING4004", description = "NOT_FOUND, 개최자가 생성한 뷰잉파티 글을 찾을수 없습니다."),
+
+    })
+    @Parameters({
+            @Parameter(name = "user_id", description = "RequestHeader - 로그인한 사용자 아이디(accessToken으로 변경 예정)"),
+            @Parameter(name = "viewing_party_id", description = "query string(RequestParam) - 해당 뷰잉파티 글의 ID"),
+    })
+    public ApiResponse<?> createViewingParty(@RequestHeader(name = "user_id") Long userId,
+                                             @RequestParam(name = "viewing_party_id") Long viewingPartyId,
+                                             @RequestBody @Valid ChangeViewingPartyDTO.CreateViewingPartyRequest request){
+        return ApiResponse.createSuccess(viewingPartyChangeService.updateViewingParty(userId, viewingPartyId, request));
+    }
+
+    @DeleteMapping("/{viewing_party_id}/delete")
+    @Operation(summary = "뷰잉파티 삭제 API", description = "뷰잉파티 글을 삭제하는 API입니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "VIEWING4005", description = "NOT_ACCEPTABLE, 뷰잉파티 글 삭제에 실패했습니다."),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "VIEWING4004", description = "NOT_FOUND, 개최자가 생성한 뷰잉파티 글을 찾을수 없습니다."),
+
+    })
+    @Parameters({
+            @Parameter(name = "user_id", description = "RequestHeader - 로그인한 사용자 아이디(accessToken으로 변경 예정)"),
+            @Parameter(name = "viewing_party_id", description = "query string(RequestParam) - 해당 뷰잉파티 글의 ID"),
+    })
+    public ApiResponse<?> createViewingParty(@RequestHeader(name = "user_id") Long userId,
+                                             @RequestParam(name = "viewing_party_id") Long viewingPartyId){
+        return ApiResponse.createSuccess(viewingPartyChangeService.deleteViewingParty(userId, viewingPartyId));
+    }
 }

--- a/src/main/java/com/lckback/lckforall/viewing/dto/ViewingPartyListDTO.java
+++ b/src/main/java/com/lckback/lckforall/viewing/dto/ViewingPartyListDTO.java
@@ -23,6 +23,7 @@ public class ViewingPartyListDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class Response {
+        Long id;
         String name;
         String userName;
         String photoURL;

--- a/src/main/java/com/lckback/lckforall/viewing/model/ViewingParty.java
+++ b/src/main/java/com/lckback/lckforall/viewing/model/ViewingParty.java
@@ -17,13 +17,10 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
+@Setter
 @Builder
 @Entity
 @Table(name = "VIEWING_PARTY")

--- a/src/main/java/com/lckback/lckforall/viewing/repository/ViewingPartyRepository.java
+++ b/src/main/java/com/lckback/lckforall/viewing/repository/ViewingPartyRepository.java
@@ -6,6 +6,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ViewingPartyRepository extends JpaRepository<ViewingParty, Long> {
     Page<ViewingParty> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    Optional<ViewingParty> findByIdAndUser(Long viewingPartyId, User user);
 }

--- a/src/main/java/com/lckback/lckforall/viewing/service/ViewingPartyChangeService.java
+++ b/src/main/java/com/lckback/lckforall/viewing/service/ViewingPartyChangeService.java
@@ -6,4 +6,7 @@ public interface ViewingPartyChangeService {
 
     ChangeViewingPartyDTO.Response createViewingParty(Long userId, ChangeViewingPartyDTO.CreateViewingPartyRequest request);
 
+    ChangeViewingPartyDTO.Response updateViewingParty(Long userId, Long viewingPartyId, ChangeViewingPartyDTO.CreateViewingPartyRequest request);
+
+    ChangeViewingPartyDTO.Response deleteViewingParty(Long userId, Long viewingPartyId);
 }

--- a/src/main/java/com/lckback/lckforall/viewing/service/ViewingPartyChangeServiceImpl.java
+++ b/src/main/java/com/lckback/lckforall/viewing/service/ViewingPartyChangeServiceImpl.java
@@ -1,6 +1,8 @@
 package com.lckback.lckforall.viewing.service;
 
 import com.lckback.lckforall.base.api.error.CommonErrorCode;
+import com.lckback.lckforall.base.api.error.UserErrorCode;
+import com.lckback.lckforall.base.api.error.ViewingPartyErrorCode;
 import com.lckback.lckforall.base.api.exception.RestApiException;
 import com.lckback.lckforall.user.model.User;
 import com.lckback.lckforall.user.respository.UserRepository;
@@ -23,10 +25,39 @@ public class ViewingPartyChangeServiceImpl implements ViewingPartyChangeService 
     @Override
     @Transactional
     public ChangeViewingPartyDTO.Response createViewingParty(Long userId, ChangeViewingPartyDTO.CreateViewingPartyRequest request) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(CommonErrorCode.USER_NOT_FOUND));
+        User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(UserErrorCode.USER_NOT_FOUND));
         ViewingParty viewingParty = ViewingPartyChangeConverter.toViewingParty(request);
         viewingParty.setUser(user);
         ViewingParty save = viewingPartyRepository.save(viewingParty);
         return ViewingPartyChangeConverter.toResponse(save);
+    }
+
+    @Override
+    @Transactional
+    public ChangeViewingPartyDTO.Response updateViewingParty(Long userId, Long viewingPartyId, ChangeViewingPartyDTO.CreateViewingPartyRequest request) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(UserErrorCode.USER_NOT_FOUND));
+        // 글 작성자 본인이 아닐경우 에러발생
+        ViewingParty viewingParty = viewingPartyRepository.findByIdAndUser(viewingPartyId, user).orElseThrow(() -> new RestApiException(ViewingPartyErrorCode.OWNER_VIEWING_PARTY_NOT_FOUND));
+        ViewingParty viewingPartyRequest = ViewingPartyChangeConverter.toViewingParty(request);
+        viewingParty.setName(viewingPartyRequest.getName());
+        viewingParty.setDate(viewingPartyRequest.getDate());
+        viewingParty.setLatitude(viewingPartyRequest.getLatitude());
+        viewingParty.setLongitude(viewingPartyRequest.getLongitude());
+        viewingParty.setPrice(viewingPartyRequest.getPrice());
+        viewingParty.setLowParticipate(viewingPartyRequest.getLowParticipate());
+        viewingParty.setHighParticipate(viewingPartyRequest.getHighParticipate());
+        viewingParty.setPartyQualify(viewingPartyRequest.getPartyQualify());
+        viewingParty.setEtc(viewingPartyRequest.getEtc());
+        ViewingParty save = viewingPartyRepository.save(viewingParty);
+        return ViewingPartyChangeConverter.toResponse(save);
+    }
+
+    @Override
+    @Transactional
+    public ChangeViewingPartyDTO.Response deleteViewingParty(Long userId, Long viewingPartyId) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new RestApiException(UserErrorCode.USER_NOT_FOUND));
+        ViewingParty viewingParty = viewingPartyRepository.findByIdAndUser(viewingPartyId, user).orElseThrow(() -> new RestApiException(ViewingPartyErrorCode.OWNER_VIEWING_PARTY_NOT_FOUND));
+        viewingPartyRepository.delete(viewingParty);
+        return ViewingPartyChangeConverter.toResponse(viewingParty);
     }
 }

--- a/src/main/java/com/lckback/lckforall/viewing/service/ViewingPartyServiceImpl.java
+++ b/src/main/java/com/lckback/lckforall/viewing/service/ViewingPartyServiceImpl.java
@@ -39,7 +39,7 @@ public class ViewingPartyServiceImpl implements ViewingPartyService {
     @Transactional
     public GetViewingPartyDetailDTO.Response getViewingPartyDetail(Long userId, Long viewingId) {
         userRepository.findById(userId).orElseThrow(() -> new RestApiException(UserErrorCode.USER_NOT_FOUND));
-        ViewingParty viewingPartyDetail = viewingPartyRepository.findById(viewingId).orElseThrow(() -> new RuntimeException(ViewingPartyErrorCode.PARTY_NOT_FOUND.getMessage()));
+        ViewingParty viewingPartyDetail = viewingPartyRepository.findById(viewingId).orElseThrow(() -> new RestApiException(ViewingPartyErrorCode.PARTY_NOT_FOUND));
         return ViewingPartyConverter.toResponse(viewingPartyDetail);
 
     }


### PR DESCRIPTION
## 개요
뷰잉파티 글 수정/삭제 API 구현
## 작업사항
글 작성자가 아닐경우 에러를 반환하도록 로직 구현, Response -> 해당 글 ID, 해당 뷰잉파티글 개최자 ID로 통일
## 변경로직
RuntimeException
### 변경 전
RuntimeException 에러
### 변경 후
RestApiException 으로 변경
## 사용방법
글 수정 : https://www.notion.so/API-38e4db9c86b644a7b1b4bcf183551a84?p=213c1df6608341428eb706e29bd8a6e6&pm=s
글 삭제 : https://www.notion.so/API-38e4db9c86b644a7b1b4bcf183551a84?p=6e50897b05fa4bb9a5ecd0f38b270777&pm=s
## 기타