### PR TITLE
[Feat/#70] get user post and comment

### DIFF
--- a/src/main/java/com/lckback/lckforall/community/repository/CommentRepository.java
+++ b/src/main/java/com/lckback/lckforall/community/repository/CommentRepository.java
@@ -1,0 +1,13 @@
+package com.lckback.lckforall.community.repository;
+
+import com.lckback.lckforall.community.model.Comment;
+import com.lckback.lckforall.user.model.User;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    Page<Comment> findByUser(User user, Pageable pageable);
+}

--- a/src/main/java/com/lckback/lckforall/community/repository/PostRepository.java
+++ b/src/main/java/com/lckback/lckforall/community/repository/PostRepository.java
@@ -1,0 +1,13 @@
+package com.lckback.lckforall.community.repository;
+
+import com.lckback.lckforall.community.model.Post;
+import com.lckback.lckforall.user.model.User;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+    Page<Post> findByUser(User user, Pageable pageable);
+}

--- a/src/main/java/com/lckback/lckforall/mypage/controller/MyPageController.java
+++ b/src/main/java/com/lckback/lckforall/mypage/controller/MyPageController.java
@@ -1,6 +1,8 @@
 package com.lckback.lckforall.mypage.controller;
 
 import com.lckback.lckforall.base.api.ApiResponse;
+import com.lckback.lckforall.mypage.dto.GetUserCommentDto;
+import com.lckback.lckforall.mypage.dto.GetUserPostDto;
 import com.lckback.lckforall.mypage.dto.GetUserProfileDto;
 import com.lckback.lckforall.mypage.dto.UpdateMyTeamDto;
 import com.lckback.lckforall.mypage.dto.UpdateUserProfileDto;
@@ -10,6 +12,8 @@ import jakarta.validation.Valid;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -74,4 +78,25 @@ public class MyPageController {
             .body(ApiResponse.createSuccessWithNoContent());
     }
 
+    @GetMapping("/posts")
+    public ResponseEntity<?> getUserPost(
+        @RequestHeader(name = "userId") Long userId,
+        @PageableDefault(size = 6) Pageable pageable) {
+
+        GetUserPostDto.Response response = myPageService.getUserPost(userId, pageable);
+
+        return ResponseEntity.ok()
+            .body(ApiResponse.createSuccess(response));
+    }
+
+    @GetMapping("/comments")
+    public ResponseEntity<?> getUseComment(
+        @RequestHeader(name = "userId") Long userId,
+        @PageableDefault(size = 6) Pageable pageable) {
+
+        GetUserCommentDto.Response response = myPageService.getUserComment(userId, pageable);
+
+        return ResponseEntity.ok()
+            .body(ApiResponse.createSuccess(response));
+    }
 }

--- a/src/main/java/com/lckback/lckforall/mypage/dto/GetUserCommentDto.java
+++ b/src/main/java/com/lckback/lckforall/mypage/dto/GetUserCommentDto.java
@@ -1,0 +1,25 @@
+package com.lckback.lckforall.mypage.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class GetUserCommentDto {
+
+    @Builder
+    @Getter
+    public static class Response {
+
+        private List<Information> comments;
+        private Boolean isLast;
+    }
+
+    @Builder
+    public static class Information {
+
+        private Long id;
+        private String content;
+        private String postType;
+    }
+}

--- a/src/main/java/com/lckback/lckforall/mypage/dto/GetUserPostDto.java
+++ b/src/main/java/com/lckback/lckforall/mypage/dto/GetUserPostDto.java
@@ -1,0 +1,28 @@
+package com.lckback.lckforall.mypage.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+public class GetUserPostDto {
+
+    @Builder
+    @Getter
+    public static class Response {
+
+        private List<Information> posts;
+        private Boolean isLast;
+    }
+
+    @Builder
+    @Getter
+    @Setter
+    public static class Information {
+
+        private Long id;
+        private String title;
+        private String postType;
+    }
+}

--- a/src/main/java/com/lckback/lckforall/mypage/service/MyPageService.java
+++ b/src/main/java/com/lckback/lckforall/mypage/service/MyPageService.java
@@ -4,6 +4,12 @@ import com.lckback.lckforall.base.api.error.CommonErrorCode;
 import com.lckback.lckforall.base.api.error.TeamErrorCode;
 import com.lckback.lckforall.base.api.error.UserErrorCode;
 import com.lckback.lckforall.base.api.exception.RestApiException;
+import com.lckback.lckforall.community.model.Comment;
+import com.lckback.lckforall.community.model.Post;
+import com.lckback.lckforall.community.repository.CommentRepository;
+import com.lckback.lckforall.community.repository.PostRepository;
+import com.lckback.lckforall.mypage.dto.GetUserCommentDto;
+import com.lckback.lckforall.mypage.dto.GetUserPostDto;
 import com.lckback.lckforall.mypage.dto.GetUserProfileDto;
 import com.lckback.lckforall.mypage.dto.UpdateMyTeamDto;
 import com.lckback.lckforall.mypage.dto.UpdateUserProfileDto;
@@ -14,8 +20,13 @@ import com.lckback.lckforall.user.respository.UserRepository;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -28,6 +39,10 @@ public class MyPageService {
 	private final UserRepository userRepository;
 
 	private final TeamRepository teamRepository;
+
+	private final PostRepository postRepository;
+
+	private final CommentRepository commentRepository;
 
 	public GetUserProfileDto.Response getUserProfile(Long userId) {
 
@@ -96,7 +111,54 @@ public class MyPageService {
 			throw new RestApiException(TeamErrorCode.MY_TEAM_CANNOT_UPDATE);
 		}
 
-
 		user.updateMyTeam(team);
 	}
+
+	public GetUserPostDto.Response getUserPost(Long userId, Pageable pageable) {
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new RestApiException(UserErrorCode.NOT_EXIST_USER));
+
+		Page<Post> posts = postRepository.findByUser(user, pageable);
+
+		return GetUserPostDto.Response.builder()
+			.posts(convertToPostInformation(posts))
+			.isLast(posts.isLast())
+			.build();
+	}
+
+	public GetUserCommentDto.Response getUserComment(Long userId, Pageable pageable) {
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new RestApiException(UserErrorCode.NOT_EXIST_USER));
+
+		Page<Comment> comments = commentRepository.findByUser(user, pageable);
+
+		return GetUserCommentDto.Response.builder()
+			.comments(convertToCommentInformation(comments))
+			.isLast(comments.isLast())
+			.build();
+	}
+
+	private List<GetUserPostDto.Information> convertToPostInformation(Page<Post> posts) {
+		return posts.stream()
+			.map(post -> GetUserPostDto.Information.builder()
+				.id(post.getId())
+				.title(post.getTitle())
+				.postType(post.getPostType().getType())
+				.build())
+			.collect(Collectors.toList());
+	}
+
+	private List<GetUserCommentDto.Information> convertToCommentInformation(
+		Page<Comment> comments) {
+		return comments.stream()
+			.map(comment -> GetUserCommentDto.Information.builder()
+				.id(comment.getId())
+				.content(comment.getContent())
+				.postType(comment.getPost().getPostType().getType())
+				.build())
+			.collect(Collectors.toList());
+	}
+
 }


### PR DESCRIPTION
## 개요
사용자의 게시글과 댓글 조회

## 작업사항
1. PostRepository, CommentRepository 추가
2. GetUserPostDto, GetUserCommentDto 추가
3. MyPageController, MyPageService : getUserPost(), getUserComment() 구현

## 변경로직

### 변경 전

### 변경 후

## 사용방법
게시글 조회 : `my-pages/posts` URI에 `Get` method로 request
댓글 조회 : `my-pages/comments` URI에 `Get` method로 request

## 기타
resolved : #70 