### PR TITLE
[Feat/#74] find and delete viewing party 

### DIFF
--- a/src/main/java/com/lckback/lckforall/base/api/error/ViewingPartyErrorCode.java
+++ b/src/main/java/com/lckback/lckforall/base/api/error/ViewingPartyErrorCode.java
@@ -11,7 +11,8 @@ public enum ViewingPartyErrorCode implements ErrorCode {
     PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "뷰잉파티를 찾을수 없습니다."),
     FAILED_PARTICIPATE_PARTY(HttpStatus.NOT_ACCEPTABLE, "뷰잉파티 참여에 실패했습니다."),
     FAILED_UPDATE_VIEWING_PARTY(HttpStatus.NOT_ACCEPTABLE, "뷰잉파티 글 수정에 실패했습니다."),
-    OWNER_VIEWING_PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "개최자가 생성한 뷰잉파티 글을 찾을수 없습니다.");
+    OWNER_VIEWING_PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "개최자가 생성한 뷰잉파티 글을 찾을수 없습니다."),
+    USER_IS_NOT_HOST(HttpStatus.BAD_REQUEST, "호스트가 아니라 뷰잉 파티 개최 취소 불가합니다.");
     private final HttpStatus httpStatus;
     private final String message;
 

--- a/src/main/java/com/lckback/lckforall/base/api/error/ViewingPartyErrorCode.java
+++ b/src/main/java/com/lckback/lckforall/base/api/error/ViewingPartyErrorCode.java
@@ -7,10 +7,11 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ViewingPartyErrorCode implements ErrorCode {
-    PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "뷰잉파티를 찾을수 없습니다."),
-    FAILED_PARTICIPATE_PARTY(HttpStatus.NOT_ACCEPTABLE, "뷰잉파티 참여에 실패했습니다.");
+	PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "뷰잉파티를 찾을수 없습니다."),
+	FAILED_PARTICIPATE_PARTY(HttpStatus.NOT_ACCEPTABLE, "뷰잉파티 참여에 실패했습니다."),
+	USER_IS_NOT_HOST(HttpStatus.BAD_REQUEST, "호스트가 아니라 뷰잉 파티 개최 취소 불가합니다.");
 
-    private final HttpStatus httpStatus;
-    private final String message;
+	private final HttpStatus httpStatus;
+	private final String message;
 
 }

--- a/src/main/java/com/lckback/lckforall/mypage/controller/MyPageController.java
+++ b/src/main/java/com/lckback/lckforall/mypage/controller/MyPageController.java
@@ -1,9 +1,12 @@
 package com.lckback.lckforall.mypage.controller;
 
 import com.lckback.lckforall.base.api.ApiResponse;
+import com.lckback.lckforall.mypage.dto.DeleteParticipationDto;
+import com.lckback.lckforall.mypage.dto.DeleteViewingPartyDto;
 import com.lckback.lckforall.mypage.dto.GetUserCommentDto;
 import com.lckback.lckforall.mypage.dto.GetUserPostDto;
 import com.lckback.lckforall.mypage.dto.GetUserProfileDto;
+import com.lckback.lckforall.mypage.dto.GetViewingPartyDto;
 import com.lckback.lckforall.mypage.dto.UpdateMyTeamDto;
 import com.lckback.lckforall.mypage.dto.UpdateUserProfileDto;
 import com.lckback.lckforall.mypage.service.MyPageService;
@@ -16,6 +19,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,72 +35,118 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class MyPageController {
 
-    private final MyPageService myPageService;
+	private final MyPageService myPageService;
 
-    @GetMapping("/profiles")
-    public ResponseEntity<?> getUserProfile(
-        @RequestHeader(name = "userId") Long userId) {
+	@GetMapping("/profiles")
+	public ResponseEntity<?> getUserProfile(
+		@RequestHeader(name = "userId") Long userId) {
 
-        GetUserProfileDto.Response response =
-            myPageService.getUserProfile(userId);
+		GetUserProfileDto.Response response =
+			myPageService.getUserProfile(userId);
 
-        return ResponseEntity.ok()
-            .body(ApiResponse.createSuccess(response));
-    }
+		return ResponseEntity.ok()
+			.body(ApiResponse.createSuccess(response));
+	}
 
-    @PatchMapping("/withdrawal")
-    public ResponseEntity<?> withdrawFromAccount(
-        @RequestHeader(name = "userId") Long userId) {
+	@PatchMapping("/withdrawal")
+	public ResponseEntity<?> withdrawFromAccount(
+		@RequestHeader(name = "userId") Long userId) {
 
-        myPageService.withdrawFromAccount(userId);
+		myPageService.withdrawFromAccount(userId);
 
-        return ResponseEntity.ok()
-            .body(ApiResponse.createSuccessWithNoContent());
-    }
-  
-    @PatchMapping("/profiles")
-    public ResponseEntity<?> updateUserProfile(
-        @RequestHeader(name = "userId") Long userId,
-        @RequestPart(required = false) MultipartFile profileImage,
-        @RequestPart @Valid UpdateUserProfileDto.Request request) {
+		return ResponseEntity.ok()
+			.body(ApiResponse.createSuccessWithNoContent());
+	}
 
-        UpdateUserProfileDto.Response response =
-            myPageService.updateUserProfile(userId, profileImage, request);
+	@PatchMapping("/profiles")
+	public ResponseEntity<?> updateUserProfile(
+		@RequestHeader(name = "userId") Long userId,
+		@RequestPart(required = false) MultipartFile profileImage,
+		@RequestPart @Valid UpdateUserProfileDto.Request request) {
 
-        return ResponseEntity.ok()
-            .body(ApiResponse.createSuccess(response));
-    }
+		UpdateUserProfileDto.Response response =
+			myPageService.updateUserProfile(userId, profileImage, request);
 
-    @PatchMapping("/my-team")
-    public ResponseEntity<?> updateMyTeam(
-        @RequestHeader(name = "userId") Long userId,
-        @RequestBody @Valid UpdateMyTeamDto.Request request) {
+		return ResponseEntity.ok()
+			.body(ApiResponse.createSuccess(response));
+	}
 
-        myPageService.updateMyTeam(userId, request);
+	@PatchMapping("/my-team")
+	public ResponseEntity<?> updateMyTeam(
+		@RequestHeader(name = "userId") Long userId,
+		@RequestBody @Valid UpdateMyTeamDto.Request request) {
 
-        return ResponseEntity.ok()
-            .body(ApiResponse.createSuccessWithNoContent());
-    }
+		myPageService.updateMyTeam(userId, request);
 
-    @GetMapping("/posts")
-    public ResponseEntity<?> getUserPost(
-        @RequestHeader(name = "userId") Long userId,
-        @PageableDefault(size = 6) Pageable pageable) {
+		return ResponseEntity.ok()
+			.body(ApiResponse.createSuccessWithNoContent());
+	}
 
-        GetUserPostDto.Response response = myPageService.getUserPost(userId, pageable);
+	@GetMapping("/posts")
+	public ResponseEntity<?> getUserPost(
+		@RequestHeader(name = "userId") Long userId,
+		@PageableDefault(size = 6) Pageable pageable) {
 
-        return ResponseEntity.ok()
-            .body(ApiResponse.createSuccess(response));
-    }
+		GetUserPostDto.Response response = myPageService.getUserPost(userId, pageable);
 
-    @GetMapping("/comments")
-    public ResponseEntity<?> getUseComment(
-        @RequestHeader(name = "userId") Long userId,
-        @PageableDefault(size = 6) Pageable pageable) {
+		return ResponseEntity.ok()
+			.body(ApiResponse.createSuccess(response));
+	}
 
-        GetUserCommentDto.Response response = myPageService.getUserComment(userId, pageable);
+	@GetMapping("/comments")
+	public ResponseEntity<?> getUseComment(
+		@RequestHeader(name = "userId") Long userId,
+		@PageableDefault(size = 6) Pageable pageable) {
 
-        return ResponseEntity.ok()
-            .body(ApiResponse.createSuccess(response));
-    }
+		GetUserCommentDto.Response response = myPageService.getUserComment(userId, pageable);
+
+		return ResponseEntity.ok()
+			.body(ApiResponse.createSuccess(response));
+	}
+
+	@GetMapping("/viewing-parties/participate")
+	public ResponseEntity<?> getUserViewingPartyAsParticipate(
+		@RequestHeader(name = "userId") Long userId,
+		@PageableDefault(size = 6) Pageable pageable) {
+
+		GetViewingPartyDto.Response response =
+			myPageService.getUserViewingPartyAsParticipate(userId, pageable);
+
+		return ResponseEntity.ok()
+			.body(ApiResponse.createSuccess(response));
+	}
+
+	@GetMapping("/viewing-parties/host")
+	public ResponseEntity<?> getUserViewingPartyAsHost(
+		@RequestHeader(name = "userId") Long userId,
+		@PageableDefault(size = 6) Pageable pageable) {
+
+		GetViewingPartyDto.Response response =
+			myPageService.getUserViewingPartyAsHost(userId, pageable);
+
+		return ResponseEntity.ok()
+			.body(ApiResponse.createSuccess(response));
+	}
+
+	@DeleteMapping("/viewing-parties/participate")
+	public ResponseEntity<?> cancelViewingPartyParticipation(
+		@RequestHeader(name = "userId") Long userId,
+		@RequestBody @Valid DeleteParticipationDto.Request request) {
+
+		myPageService.cancelViewingPartyParticipation(userId, request);
+
+		return ResponseEntity.ok()
+			.body(ApiResponse.createSuccessWithNoContent());
+	}
+
+	@DeleteMapping("/viewing-parties/host")
+	public ResponseEntity<?> cancelViewingPartyHosting(
+		@RequestHeader(name = "userId") Long userId,
+		@RequestBody @Valid DeleteViewingPartyDto.Request request) {
+
+		myPageService.cancelViewingPartyHosting(userId, request);
+
+		return ResponseEntity.ok()
+			.body(ApiResponse.createSuccessWithNoContent());
+	}
 }

--- a/src/main/java/com/lckback/lckforall/mypage/dto/DeleteParticipationDto.java
+++ b/src/main/java/com/lckback/lckforall/mypage/dto/DeleteParticipationDto.java
@@ -1,0 +1,17 @@
+package com.lckback.lckforall.mypage.dto;
+
+import jakarta.validation.constraints.Positive;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class DeleteParticipationDto {
+
+	@NoArgsConstructor
+	@Getter
+	public static class Request {
+
+		@Positive
+		private Long viewingPartyId;
+	}
+}

--- a/src/main/java/com/lckback/lckforall/mypage/dto/DeleteViewingPartyDto.java
+++ b/src/main/java/com/lckback/lckforall/mypage/dto/DeleteViewingPartyDto.java
@@ -1,0 +1,17 @@
+package com.lckback.lckforall.mypage.dto;
+
+import jakarta.validation.constraints.Positive;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class DeleteViewingPartyDto {
+
+    @NoArgsConstructor
+    @Getter
+    public static class Request {
+
+        @Positive
+        private Long viewingPartyId;
+    }
+}

--- a/src/main/java/com/lckback/lckforall/mypage/dto/GetUserCommentDto.java
+++ b/src/main/java/com/lckback/lckforall/mypage/dto/GetUserCommentDto.java
@@ -16,6 +16,7 @@ public class GetUserCommentDto {
     }
 
     @Builder
+    @Getter
     public static class Information {
 
         private Long id;

--- a/src/main/java/com/lckback/lckforall/mypage/dto/GetViewingPartyDto.java
+++ b/src/main/java/com/lckback/lckforall/mypage/dto/GetViewingPartyDto.java
@@ -1,0 +1,26 @@
+package com.lckback.lckforall.mypage.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class GetViewingPartyDto {
+
+    @Builder
+    @Getter
+    public static class Response {
+
+        private List<Information> viewingParties;
+        private boolean isLast;
+    }
+
+    @Builder
+    @Getter
+    public static class Information {
+
+        private Long id;
+        private String name;
+        private String date;
+    }
+}

--- a/src/main/java/com/lckback/lckforall/mypage/service/MyPageService.java
+++ b/src/main/java/com/lckback/lckforall/mypage/service/MyPageService.java
@@ -3,22 +3,31 @@ package com.lckback.lckforall.mypage.service;
 import com.lckback.lckforall.base.api.error.CommonErrorCode;
 import com.lckback.lckforall.base.api.error.TeamErrorCode;
 import com.lckback.lckforall.base.api.error.UserErrorCode;
+import com.lckback.lckforall.base.api.error.ViewingPartyErrorCode;
 import com.lckback.lckforall.base.api.exception.RestApiException;
 import com.lckback.lckforall.community.model.Comment;
 import com.lckback.lckforall.community.model.Post;
 import com.lckback.lckforall.community.repository.CommentRepository;
 import com.lckback.lckforall.community.repository.PostRepository;
+import com.lckback.lckforall.mypage.dto.DeleteParticipationDto;
+import com.lckback.lckforall.mypage.dto.DeleteViewingPartyDto;
 import com.lckback.lckforall.mypage.dto.GetUserCommentDto;
 import com.lckback.lckforall.mypage.dto.GetUserPostDto;
 import com.lckback.lckforall.mypage.dto.GetUserProfileDto;
+import com.lckback.lckforall.mypage.dto.GetViewingPartyDto;
 import com.lckback.lckforall.mypage.dto.UpdateMyTeamDto;
 import com.lckback.lckforall.mypage.dto.UpdateUserProfileDto;
 import com.lckback.lckforall.team.model.Team;
 import com.lckback.lckforall.team.repository.TeamRepository;
 import com.lckback.lckforall.user.model.User;
 import com.lckback.lckforall.user.respository.UserRepository;
+import com.lckback.lckforall.viewing.model.Participate;
+import com.lckback.lckforall.viewing.model.ViewingParty;
+import com.lckback.lckforall.viewing.repository.ParticipateRepository;
+import com.lckback.lckforall.viewing.repository.ViewingPartyRepository;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -43,6 +52,10 @@ public class MyPageService {
 	private final PostRepository postRepository;
 
 	private final CommentRepository commentRepository;
+
+	private final ParticipateRepository participateRepository;
+
+	private final ViewingPartyRepository viewingPartyRepository;
 
 	public GetUserProfileDto.Response getUserProfile(Long userId) {
 
@@ -140,6 +153,71 @@ public class MyPageService {
 			.build();
 	}
 
+	public GetViewingPartyDto.Response getUserViewingPartyAsParticipate(
+		Long userId,
+		Pageable pageable) {
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new RestApiException(UserErrorCode.NOT_EXIST_USER));
+
+		Page<Participate> participates = participateRepository.findByUser(user, pageable);
+
+		Page<ViewingParty> viewingParties = participates
+			.map(participate -> participate.getViewingParty());
+
+		return GetViewingPartyDto.Response.builder()
+			.viewingParties(convertToViewingPartiesInformation(viewingParties))
+			.isLast(viewingParties.isLast())
+			.build();
+	}
+
+	public GetViewingPartyDto.Response getUserViewingPartyAsHost(Long userId, Pageable pageable) {
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new RestApiException(UserErrorCode.NOT_EXIST_USER));
+
+		Page<ViewingParty> viewingParties = viewingPartyRepository.findByUser(user, pageable);
+
+		return GetViewingPartyDto.Response.builder()
+			.viewingParties(convertToViewingPartiesInformation(viewingParties))
+			.isLast(viewingParties.isLast())
+			.build();
+	}
+
+	public void cancelViewingPartyParticipation(
+		Long userId,
+		DeleteParticipationDto.Request request) {
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new RestApiException(UserErrorCode.NOT_EXIST_USER));
+
+		ViewingParty viewingParty = viewingPartyRepository.findById(request.getViewingPartyId())
+			.orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+
+		Participate participate =
+			participateRepository.findByViewingPartyAndUser(viewingParty, user)
+				.orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+
+		participateRepository.delete(participate);
+	}
+
+	public void cancelViewingPartyHosting(
+		Long userId,
+		DeleteViewingPartyDto.Request request) {
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new RestApiException(UserErrorCode.NOT_EXIST_USER));
+
+		ViewingParty viewingParty = viewingPartyRepository.findById(request.getViewingPartyId())
+			.orElseThrow(() -> new RestApiException(CommonErrorCode.RESOURCE_NOT_FOUND));
+
+		if (!viewingParty.getUser().equals(user)) {
+			throw new RestApiException(ViewingPartyErrorCode.USER_IS_NOT_HOST);
+		}
+
+		viewingPartyRepository.delete(viewingParty);
+	}
+
 	private List<GetUserPostDto.Information> convertToPostInformation(Page<Post> posts) {
 		return posts.stream()
 			.map(post -> GetUserPostDto.Information.builder()
@@ -161,4 +239,15 @@ public class MyPageService {
 			.collect(Collectors.toList());
 	}
 
+	private List<GetViewingPartyDto.Information> convertToViewingPartiesInformation(
+		Page<ViewingParty> viewingParties) {
+
+		return viewingParties.stream()
+			.map(viewingParty -> GetViewingPartyDto.Information.builder()
+				.id(viewingParty.getId())
+				.name(viewingParty.getName())
+				.date(viewingParty.getDate().format(DateTimeFormatter.ofPattern("yyyy.MM.dd")))
+				.build()
+			).collect(Collectors.toList());
+	}
 }

--- a/src/main/java/com/lckback/lckforall/viewing/model/ViewingParty.java
+++ b/src/main/java/com/lckback/lckforall/viewing/model/ViewingParty.java
@@ -69,7 +69,7 @@ public class ViewingParty extends BaseEntity {
 	@JoinColumn(name = "USER_ID", nullable = false)
 	private User user;
 
-	@OneToMany(mappedBy = "viewingParty")
+	@OneToMany(mappedBy = "viewingParty", orphanRemoval = true)
 	private List<Participate> participates = new ArrayList<>();
 
 	public void setUser(User user) {

--- a/src/main/java/com/lckback/lckforall/viewing/repository/ParticipateRepository.java
+++ b/src/main/java/com/lckback/lckforall/viewing/repository/ParticipateRepository.java
@@ -3,6 +3,9 @@ package com.lckback.lckforall.viewing.repository;
 import com.lckback.lckforall.user.model.User;
 import com.lckback.lckforall.viewing.model.Participate;
 import com.lckback.lckforall.viewing.model.ViewingParty;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -10,4 +13,8 @@ import java.util.Optional;
 public interface ParticipateRepository extends JpaRepository<Participate, Long> {
 
     Optional<Participate> findByUserAndViewingParty(User user, ViewingParty viewingParty);
+
+    Page<Participate> findByUser(User user, Pageable pageable);
+
+    Optional<Participate> findByViewingPartyAndUser(ViewingParty viewingParty, User user);
 }

--- a/src/main/java/com/lckback/lckforall/viewing/repository/ViewingPartyRepository.java
+++ b/src/main/java/com/lckback/lckforall/viewing/repository/ViewingPartyRepository.java
@@ -7,5 +7,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ViewingPartyRepository extends JpaRepository<ViewingParty, Long> {
-    Page<ViewingParty> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+	Page<ViewingParty> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+	Page<ViewingParty> findByUser(User user, Pageable pageable);
+
 }


### PR DESCRIPTION
## 개요
마이페이지 뷰잉 파티 관련 로직 구현

## 작업사항
1. GetViewingPartyDto, DeleteParticipationDto, DeleteViewingPartyDto 추가
2. ViewingPartyRepository : findByUser() 추가
3. ParticipationRepository : findByUser()m findByViewingPartyAndUser() 추가
5. ViewingParty : orphanRemoval 적용
6. ViewingPartyErrorCode : 뷰잉 파티 개최 취소 권한 에러 코드 추가
7. MyPageService, MyPageController : 뷰잉 파티 조회, 참여 취소, 개최 취소 로직 추가

## 변경로직

### 변경 전

### 변경 후

## 사용방법

## 기타