### PR TITLE
[Refactor#116] swagger pageable처리 및 api tag, opertaion 추가 (커스텀 어노테이션 활용)

### DIFF
--- a/src/main/java/com/lckback/lckforall/aboutlck/controller/AboutLckMatchController.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/controller/AboutLckMatchController.java
@@ -11,17 +11,21 @@ import com.lckback.lckforall.aboutlck.dto.match.FindMatchesByDateDto;
 import com.lckback.lckforall.aboutlck.service.AboutLckMatchService;
 import com.lckback.lckforall.base.api.ApiResponse;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/aboutlck/match")
 @RequiredArgsConstructor
 @SecurityRequirement(name = "JWT Token")
+@Tag(name = "AboutLckMatch", description = "AboutLck 경기 정보 조회 API")
 public class AboutLckMatchController {
 
 	private final AboutLckMatchService aboutLckMatchService;
 
+	@Operation(summary = "경기 정보 조회 API", description = "특정 날짜의 경기 정보를 조회합니다.")
 	@GetMapping
 	public ApiResponse<FindMatchesByDateDto.Response> findMatchInformationByDate(
 		@RequestParam("searchDate") LocalDate searchDate) {

--- a/src/main/java/com/lckback/lckforall/aboutlck/controller/AboutLckPlayerController.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/controller/AboutLckPlayerController.java
@@ -11,18 +11,23 @@ import com.lckback.lckforall.aboutlck.dto.player.FindPlayerTeamHistoryDto;
 import com.lckback.lckforall.aboutlck.dto.player.FindPlayerWinningHistoryDto;
 import com.lckback.lckforall.aboutlck.service.AboutLckPlayerService;
 import com.lckback.lckforall.base.api.ApiResponse;
+import com.lckback.lckforall.base.setting.SwaggerPageable;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/aboutlck/player")
 @RequiredArgsConstructor
 @SecurityRequirement(name = "JWT Token")
+@Tag(name = "AboutLckPlayer", description = "AboutLck 선수 정보 조회 API")
 public class AboutLckPlayerController {
 
 	private final AboutLckPlayerService aboutLckPlayerService;
 
+	@Operation(summary = "선수 정보 조회 API", description = "특정 선수의 정보를 조회합니다.")
 	@GetMapping("/{playerId}/information")
 	public ApiResponse<FindPlayerInformationDto.Response> findPlayerInformation(
 		@PathVariable("playerId") Long playerId) {
@@ -35,6 +40,8 @@ public class AboutLckPlayerController {
 		return ApiResponse.createSuccess(data);
 	}
 
+	@SwaggerPageable
+	@Operation(summary = "선수 팀 이력 조회 API", description = "특정 선수의 팀 이력을 조회합니다.")
 	@GetMapping("/{playerId}/team-history")
 	public ApiResponse<FindPlayerTeamHistoryDto.Response> findPlayerTeamHistory(
 		@PathVariable("playerId") Long playerId,
@@ -48,6 +55,8 @@ public class AboutLckPlayerController {
 		return ApiResponse.createSuccess(data);
 	}
 
+	@SwaggerPageable
+	@Operation(summary = "선수 우승 기록 조회 API", description = "특정 선수의 우승 기록을 조회합니다.")
 	@GetMapping("/{playerId}/winning-history")
 	public ApiResponse<FindPlayerWinningHistoryDto.Response> findPlayerWinningHistory(
 		@PathVariable("playerId") Long playerId,

--- a/src/main/java/com/lckback/lckforall/aboutlck/controller/AboutLckTeamController.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/controller/AboutLckTeamController.java
@@ -14,19 +14,25 @@ import com.lckback.lckforall.aboutlck.dto.team.FindTeamRatingBySeasonDto;
 import com.lckback.lckforall.aboutlck.dto.team.FindTeamWinningHistoryDto;
 import com.lckback.lckforall.aboutlck.service.AboutLckTeamService;
 import com.lckback.lckforall.base.api.ApiResponse;
+import com.lckback.lckforall.base.setting.SwaggerPageable;
 import com.lckback.lckforall.base.type.PlayerRole;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/aboutlck/team")
 @RequiredArgsConstructor
 @SecurityRequirement(name = "JWT Token")
+@Tag(name = "AboutLckTeam", description = "AboutLck 팀 정보 조회 API")
 public class AboutLckTeamController {
 
 	private final AboutLckTeamService aboutLckTeamService;
 
+	@SwaggerPageable
+	@Operation(summary = "팀 순위 조회 API", description = "특정 시즌의 팀 순위를 조회합니다.")
 	@GetMapping("/rating")
 	public ApiResponse<FindTeamRatingBySeasonDto.Response> findTeamRatingBySeason(
 		@RequestParam("seasonName") String seasonName,
@@ -40,6 +46,8 @@ public class AboutLckTeamController {
 		return ApiResponse.createSuccess(data);
 	}
 
+	@SwaggerPageable
+	@Operation(summary = "팀 우승 기록 조회 API", description = "특정 팀의 우승 기록을 조회합니다.")
 	@GetMapping("/{teamId}/winning-history")
 	public ApiResponse<FindTeamWinningHistoryDto.Response> findTeamWinningHistory(
 		@PathVariable("teamId") Long teamId,
@@ -53,6 +61,8 @@ public class AboutLckTeamController {
 		return ApiResponse.createSuccess(data);
 	}
 
+	@SwaggerPageable
+	@Operation(summary = "팀 최근 시즌 순위 조회 API", description = "특정 팀의 최근 순위를 조회합니다.")
 	@GetMapping("/{teamId}/rating-history")
 	public ApiResponse<FindTeamRatingHistoryDto.Response> findTeamRatingHistory(
 		@PathVariable("teamId") Long teamId,
@@ -66,6 +76,8 @@ public class AboutLckTeamController {
 		return ApiResponse.createSuccess(data);
 	}
 
+	@SwaggerPageable
+	@Operation(summary = "팀 선수 기록 조회 API", description = "특정 팀의 선수 기록을 조회합니다.")
 	@GetMapping("/{teamId}/player-history")
 	public ApiResponse<FindTeamPlayerHistoryDto.Response> findTeamPlayerHistory(
 		@PathVariable("teamId") Long teamId,
@@ -79,6 +91,7 @@ public class AboutLckTeamController {
 		return ApiResponse.createSuccess(data);
 	}
 
+	@Operation(summary = "팀 선수 정보 조회 API", description = "특정 팀의 선수 정보를 조회합니다.")
 	@GetMapping("/{teamId}/player-information")
 	public ApiResponse<FindTeamPlayerInformationDto.Response> findTeamPlayerInformationBySeasonAndRole(
 		@PathVariable("teamId") Long teamId,

--- a/src/main/java/com/lckback/lckforall/base/setting/SwaggerPageable.java
+++ b/src/main/java/com/lckback/lckforall/base/setting/SwaggerPageable.java
@@ -1,0 +1,35 @@
+package com.lckback.lckforall.base.setting;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Parameters({
+	@Parameter(
+		in = ParameterIn.QUERY,
+		name = "page",
+		description = "페이지 번호",
+		schema = @io.swagger.v3.oas.annotations.media.Schema(type = "integer", defaultValue = "0"),
+		required = true
+	),
+	@Parameter(
+		in = ParameterIn.QUERY,
+		name = "size",
+		description = "페이지 크기",
+		schema = @io.swagger.v3.oas.annotations.media.Schema(type = "integer", defaultValue = "10"),
+		required = true
+	),
+	@Parameter(
+		name = "pageable",
+		hidden = true
+	)
+})
+public @interface SwaggerPageable {
+}


### PR DESCRIPTION
## 개요

## 작업사항
swagger에서 pageable 처리를 위한 어노테이션 추가
aboutlck api 관련 명세 작업
## 변경로직
@SwaggerPageable 어노테이션 추가
### 변경 전
@PageableAsQueryParam 과 @Parameter(hidden=true)로 pagealbe처리 했어야 함
1. queryparam이 required가 아님
2. 설명이 영어로 표시됨
### 변경 후
@SwaggerPageable 어노테이션 작성
1. pageable 을 파라미터로 받는 api 메서드에 추가
2. queryparam이 필수 요소로 됨
3. sort삭제 (나중에 필요시 추가)
## 사용방법
@SwaggerPageble 어노테이션 api 메서드에 추가
<img width="584" alt="스크린샷 2024-08-11 오후 3 24 54" src="https://github.com/user-attachments/assets/124b9cf6-54b3-44a8-87e2-9cdae208a8c6">
swagger에 적용된 모습
<img width="624" alt="스크린샷 2024-08-11 오후 3 25 25" src="https://github.com/user-attachments/assets/baaf78a6-3cce-4c6c-8f44-1b03b6d53bf3">

## 기타