### PR TITLE
[Refactor/#226] about lck team filtering current season in winning history

### DIFF
--- a/src/main/java/com/lckback/lckforall/aboutlck/service/AboutLckPlayerService.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/service/AboutLckPlayerService.java
@@ -15,9 +15,11 @@ import com.lckback.lckforall.aboutlck.dto.player.FindPlayerInformationDto;
 import com.lckback.lckforall.aboutlck.dto.player.FindPlayerTeamHistoryDto;
 import com.lckback.lckforall.aboutlck.dto.player.FindPlayerWinningHistoryDto;
 import com.lckback.lckforall.base.api.error.PlayerErrorCode;
+import com.lckback.lckforall.base.api.error.SeasonErrorCode;
 import com.lckback.lckforall.player.repository.SeasonTeamPlayerRepository;
+import com.lckback.lckforall.team.model.Season;
+import com.lckback.lckforall.team.repository.SeasonRepository;
 import com.lckback.lckforall.team.repository.SeasonTeamRepository;
-import com.lckback.lckforall.base.api.error.CommonErrorCode;
 import com.lckback.lckforall.base.api.exception.RestApiException;
 import com.lckback.lckforall.player.model.Player;
 import com.lckback.lckforall.player.model.SeasonTeamPlayer;
@@ -32,6 +34,7 @@ import lombok.RequiredArgsConstructor;
 public class AboutLckPlayerService {
 
 	private final PlayerRepository playerRepository;
+	private final SeasonRepository seasonRepository;
 	private final SeasonTeamRepository seasonTeamRepository;
 	private final SeasonTeamPlayerRepository seasonTeamPlayerRepository;
 
@@ -64,12 +67,15 @@ public class AboutLckPlayerService {
 		FindPlayerWinningHistoryDto.Parameter parameter) {
 		Player player = findPlayerByPlayerId(parameter.getPlayerId());
 
+		Season currentSeason = seasonRepository.findByName("2024 Summer")
+			.orElseThrow(() -> new RestApiException(SeasonErrorCode.NOT_EXIST_SEASON));
+
 		List<SeasonTeamPlayer> seasonTeamPlayers = seasonTeamPlayerRepository.findAllByPlayer(player);
 
 		PageRequest pageRequest = createPageRequestSortBySeasonName(parameter.getPageable());
 
 		Page<SeasonTeam> seasonTeams = seasonTeamRepository.findWinningSeasonTeamBySeasonTeamPlayers(
-			seasonTeamPlayers, pageRequest);
+			seasonTeamPlayers, currentSeason, pageRequest);
 
 		return FindPlayerWinningHistoryConverter.toResponse(seasonTeams);
 	}

--- a/src/main/java/com/lckback/lckforall/aboutlck/service/AboutLckTeamService.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/service/AboutLckTeamService.java
@@ -1,5 +1,6 @@
 package com.lckback.lckforall.aboutlck.service;
 
+import java.util.Comparator;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
@@ -102,6 +103,7 @@ public class AboutLckTeamService {
 		List<SeasonTeamPlayer> seasonTeamPlayers = seasonTeamPlayerRepository.findAllBySeasonTeam(seasonTeam)
 			.stream()
 			.filter(seasonTeamPlayer -> seasonTeamPlayer.getPlayer().getRole().equals(param.getPlayerRole()))
+			.sorted(Comparator.comparing(seasonTeamPlayer -> seasonTeamPlayer.getPlayer().getPosition()))
 			.toList();
 
 		return FindTeamPlayerInformationConverter.convertToResponse(seasonTeamPlayers);

--- a/src/main/java/com/lckback/lckforall/aboutlck/service/AboutLckTeamService.java
+++ b/src/main/java/com/lckback/lckforall/aboutlck/service/AboutLckTeamService.java
@@ -57,9 +57,14 @@ public class AboutLckTeamService {
 	public FindTeamWinningHistoryDto.Response findTeamWinningHistory(FindTeamWinningHistoryDto.Parameter param) {
 		Team team = findTeamByTeamId(param.getTeamId());
 
+		// 현재 시즌 가져와서 필터링
+		Season currentSeason = seasonRepository.findByName("2024 Summer")
+			.orElseThrow(() -> new RestApiException(SeasonErrorCode.NOT_EXIST_SEASON));
+
 		PageRequest pageRequest = createPageRequestSortBySeasonName(param.getPageable());
 
-		Page<SeasonTeam> seasonTeams = seasonTeamRepository.findAllByTeamAndRating(team, 1,
+		Page<SeasonTeam> seasonTeams = seasonTeamRepository.findAllByTeamAndRatingAndSeasonIsNot(team, 1,
+			currentSeason,
 			pageRequest);
 
 		return FindTeamWinningHistoryConverter.convertToResponse(seasonTeams);
@@ -68,8 +73,11 @@ public class AboutLckTeamService {
 	public FindTeamRatingHistoryDto.Response findTeamRatingHistory(FindTeamRatingHistoryDto.Parameter param) {
 		Team team = findTeamByTeamId(param.getTeamId());
 
+		Season currentSeason = seasonRepository.findByName("2024 Summer")
+			.orElseThrow(() -> new RestApiException(SeasonErrorCode.NOT_EXIST_SEASON));
+
 		PageRequest pageRequest = createPageRequestSortBySeasonName(param.getPageable());
-		Page<SeasonTeam> seasonTeams = seasonTeamRepository.findAllByTeam(team, pageRequest);
+		Page<SeasonTeam> seasonTeams = seasonTeamRepository.findAllByTeamAndSeasonIsNot(team, currentSeason, pageRequest);
 
 		return FindTeamRatingHistoryConverter.convertToResponse(seasonTeams);
 	}

--- a/src/main/java/com/lckback/lckforall/team/repository/SeasonTeamRepository.java
+++ b/src/main/java/com/lckback/lckforall/team/repository/SeasonTeamRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.stereotype.Repository;
 
 import com.lckback.lckforall.player.model.SeasonTeamPlayer;
 import com.lckback.lckforall.team.model.Season;
@@ -20,19 +19,22 @@ public interface SeasonTeamRepository extends JpaRepository<SeasonTeam, Long> {
 	Page<SeasonTeam> findAllBySeasonOrderByRatingAsc(Season season, Pageable pageable);
 
 	@EntityGraph(attributePaths = {"season"})
-	Page<SeasonTeam> findAllByTeamAndRating(Team team, Integer rating, Pageable pageable);
+	Page<SeasonTeam> findAllByTeamAndRatingAndSeasonIsNot(Team team, Integer rating, Season season, Pageable pageable);
 
 	@EntityGraph(attributePaths = {"season"})
 	Page<SeasonTeam> findAllByTeam(Team team, Pageable pageable);
+
+	@EntityGraph(attributePaths = {"season"})
+	Page<SeasonTeam> findAllByTeamAndSeasonIsNot(Team team, Season season, Pageable pageable);
 
 	@EntityGraph(attributePaths = {"team", "season"})
 	@Query("select st from SeasonTeam st join st.seasonTeamPlayers stp where stp in :seasonTeamPlayers")
 	Page<SeasonTeam> findAllBySeasonTeamPlayersIn(List<SeasonTeamPlayer> seasonTeamPlayers, Pageable pageable);
 
 	@EntityGraph(attributePaths = {"season"})
-	@Query("select st from SeasonTeam st join st.seasonTeamPlayers stp where st.rating = 1 and stp in :seasonTeamPlayers")
-	Page<SeasonTeam> findWinningSeasonTeamBySeasonTeamPlayers(List<SeasonTeamPlayer> seasonTeamPlayers,
+	@Query("select st from SeasonTeam st join st.seasonTeamPlayers stp where st.rating = 1 and stp in :seasonTeamPlayers and st.season != :season")
+	Page<SeasonTeam> findWinningSeasonTeamBySeasonTeamPlayers(List<SeasonTeamPlayer> seasonTeamPlayers, Season season,
 		Pageable pageable);
 
-	Optional<SeasonTeam> findBySeasonAndTeam (Season season, Team team);
+	Optional<SeasonTeam> findBySeasonAndTeam(Season season, Team team);
 }


### PR DESCRIPTION
## 개요
순위 정보 조회 api에 현재 시즌 제외 필터링 적용
## 작업사항

## 변경로직
service에서 player position에 따라 정렬하도록 로직 수정
### 변경 전

### 변경 후

## 사용방법

## 기타