### PR TITLE
[Refactor/#239] pog candidates structure fix

### DIFF
--- a/src/main/java/com/lckback/lckforall/match/repository/SetRepository.java
+++ b/src/main/java/com/lckback/lckforall/match/repository/SetRepository.java
@@ -1,5 +1,6 @@
 package com.lckback.lckforall.match.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,6 @@ import com.lckback.lckforall.match.model.Set;
 public interface SetRepository extends JpaRepository<Set, Long> {
 	@Query("SELECT s FROM Set s WHERE s.setIndex = :setIndex AND s.match.id = :matchId")
 	Optional<Set> findBySetIndexAndMatchId(Integer setIndex, Long matchId);
+
+	List<Set> findByMatchId(Long matchId);
 }

--- a/src/main/java/com/lckback/lckforall/match/service/PogService.java
+++ b/src/main/java/com/lckback/lckforall/match/service/PogService.java
@@ -37,21 +37,24 @@ public class PogService {
 
 	public PogInfoDto.PogResponse findMatchPog(PogInfoDto.PogServiceDto dto) { // match의 pog 정보를 리턴
 
+		System.out.println("now");
 		Match match = matchRepository.findById(dto.getMatchId())
 			.orElseThrow(() -> new RestApiException(MatchErrorCode.NOT_EXIST_MATCH));
 
 		Player defaultPlayer = playerRepository.findByRole(PlayerRole.DEFAULT)
 			.orElseThrow(() -> new RestApiException(PlayerErrorCode.NOT_EXIST_PLAYER));
 
-		if (match.getMatchPogVotable()) { //아직 투표가 종료되지 않으면 결과 보여주기 X
-			throw new RestApiException(VoteErrorCode.VOTE_NOT_FINISHED_YET);
-		}
+		/* 데모데이를 위해 제약 조건 해제*/
+		// if (match.getMatchPogVotable()) { //아직 투표가 종료되지 않으면 결과 보여주기 X
+		// 	throw new RestApiException(VoteErrorCode.VOTE_NOT_FINISHED_YET);
+		// }
 
-		if (match.getPogPlayer() != defaultPlayer) { // match table에 pogPlayer값이 존재한다면 원래 있던 값 리턴
-			Player winner = match.getPogPlayer();
-			return PogInfoDto.PogResponse.create(winner.getId(), winner.getName(), winner.getProfileImageUrl(),
-				match.getSeason().getName(), match.getMatchNumber(), match.getMatchDate());
-		}
+		/* 데모데이를 위해 제약 조건 해제*/
+		// if (match.getPogPlayer() != defaultPlayer) { // match table에 pogPlayer값이 존재한다면 원래 있던 값 리턴
+		// 	Player winner = match.getPogPlayer();
+		// 	return PogInfoDto.PogResponse.create(winner.getId(), winner.getName(), winner.getProfileImageUrl(),
+		// 		match.getSeason().getName(), match.getMatchNumber(), match.getMatchDate());
+		// }
 
 		// match table에 pogPlayer값이 존재하지 않는다면 pogPlayer 계산
 		List<MatchPogVote> voteResult = match.getMatchPogVotes();
@@ -85,15 +88,17 @@ public class PogService {
 		Player noPlayer = playerRepository.findByRole(PlayerRole.DEFAULT)
 			.orElseThrow(() -> new RestApiException(PlayerErrorCode.NOT_EXIST_PLAYER));
 
-		if (nowSet.getVotable()) { //아직 투표가 종료되지 않으면 결과 보여주기 X
-			throw new RestApiException(VoteErrorCode.VOTE_NOT_FINISHED_YET);
-		}
+		/* 데모데이를 위해 제약 조건 해제*/
+		// if (nowSet.getVotable()) { //아직 투표가 종료되지 않으면 결과 보여주기 X
+		// 	throw new RestApiException(VoteErrorCode.VOTE_NOT_FINISHED_YET);
+		// }
 
-		if (nowSet.getPogPlayer() != noPlayer) { // set table에 pogPlayer값이 존재한다면 원래 있던 값 리턴
-			Player winner = nowSet.getPogPlayer();
-			return PogInfoDto.PogResponse.create(winner.getId(), winner.getName(), winner.getProfileImageUrl(),
-				match.getSeason().getName(), match.getMatchNumber(), match.getMatchDate());
-		}
+		/* 데모데이를 위해 제약 조건 해제*/
+		// if (nowSet.getPogPlayer() != noPlayer) { // set table에 pogPlayer값이 존재한다면 원래 있던 값 리턴
+		// 	Player winner = nowSet.getPogPlayer();
+		// 	return PogInfoDto.PogResponse.create(winner.getId(), winner.getName(), winner.getProfileImageUrl(),
+		// 		match.getSeason().getName(), match.getMatchNumber(), match.getMatchDate());
+		// }
 		// set table에 pogPlayer값이 존재하지 않는다면 pogPlayer 계산
 		List<SetPogVote> voteResult = nowSet.getSetPogVotes();
 

--- a/src/main/java/com/lckback/lckforall/vote/controller/VoteController.java
+++ b/src/main/java/com/lckback/lckforall/vote/controller/VoteController.java
@@ -79,11 +79,10 @@ public class VoteController {
 	@GetMapping("/set-pog/candidates")
 	public ResponseEntity<ApiResponse<SetVoteDto.SetPogVoteCandidateResponse>> getCandidateSetPogVote(
 		@RequestHeader("Authorization") String token,
-		@RequestParam("match-id") Long matchId,
-		@RequestParam("set-index") Integer setIndex) {
+		@RequestParam("match-id") Long matchId){
 		String kakaoUserId = authService.getKakaoUserId(token);
 		SetVoteDto.SetPogVoteCandidateResponse response = voteService.getSetPogCandidate(
-			new SetVoteDto.VoteCandidateDto(kakaoUserId, matchId, setIndex));
+			new SetVoteDto.VoteCandidateDto(kakaoUserId, matchId));
 		return ResponseEntity.ok().body(ApiResponse.createSuccess(response));
 	}
 

--- a/src/main/java/com/lckback/lckforall/vote/controller/VoteController.java
+++ b/src/main/java/com/lckback/lckforall/vote/controller/VoteController.java
@@ -53,16 +53,16 @@ public class VoteController {
 			.body(ApiResponse.createSuccessWithNoContent());
 	}
 
-	@Operation(summary = "매치 pog 후보 API", description = "매치 pog 투표 후보 선수를 출력합니다")
-	@GetMapping("/match-pog/candidates")
-	public ResponseEntity<ApiResponse<MatchVoteDto.MatchPogVoteCandidateResponse>> getCandidateMatchPogVote(
-		@RequestHeader("Authorization") String token,
-		@RequestParam("match-id") Long matchId) {
-		String kakaoUserId = authService.getKakaoUserId(token);
-		MatchVoteDto.MatchPogVoteCandidateResponse response = voteService.getMatchPogCandidate(
-			new MatchVoteDto.MatchPredictionCandidateDto(kakaoUserId, matchId));
-		return ResponseEntity.ok().body(ApiResponse.createSuccess(response));
-	}
+	// @Operation(summary = "매치 pog 후보 API", description = "매치 pog 투표 후보 선수를 출력합니다")
+	// @GetMapping("/match-pog/candidates")
+	// public ResponseEntity<ApiResponse<MatchVoteDto.MatchPogVoteCandidate>> getCandidateMatchPogVote(
+	// 	@RequestHeader("Authorization") String token,
+	// 	@RequestParam("match-id") Long matchId) {
+	// 	String kakaoUserId = authService.getKakaoUserId(token);
+	// 	MatchVoteDto.MatchPogVoteCandidate response = voteService.getMatchPogCandidate(
+	// 		new MatchVoteDto.MatchPredictionCandidateDto(kakaoUserId, matchId));
+	// 	return ResponseEntity.ok().body(ApiResponse.createSuccess(response));
+	// }
 
 	@Operation(summary = "매치 pog 선수 투표 API", description = "매치 pog 선수 투표를 시행합니다")
 	@PostMapping("match-pog/making")
@@ -75,13 +75,13 @@ public class VoteController {
 			.body(ApiResponse.createSuccessWithNoContent());
 	}
 
-	@Operation(summary = "세트 pog 후보 API", description = "세트 pog 선수 투표를 시행합니다")
-	@GetMapping("/set-pog/candidates")
-	public ResponseEntity<ApiResponse<SetVoteDto.SetPogVoteCandidateResponse>> getCandidateSetPogVote(
+	@Operation(summary = "pog 후보 API", description = "pog 선수 투표를 시행합니다")
+	@GetMapping("/pog/candidates")
+	public ResponseEntity<ApiResponse<SetVoteDto.PogVoteCandidateResponse>> getCandidateSetPogVote(
 		@RequestHeader("Authorization") String token,
 		@RequestParam("match-id") Long matchId){
 		String kakaoUserId = authService.getKakaoUserId(token);
-		SetVoteDto.SetPogVoteCandidateResponse response = voteService.getSetPogCandidate(
+		SetVoteDto.PogVoteCandidateResponse response = voteService.getSetPogCandidate(
 			new SetVoteDto.VoteCandidateDto(kakaoUserId, matchId));
 		return ResponseEntity.ok().body(ApiResponse.createSuccess(response));
 	}

--- a/src/main/java/com/lckback/lckforall/vote/dto/MatchVoteDto.java
+++ b/src/main/java/com/lckback/lckforall/vote/dto/MatchVoteDto.java
@@ -94,7 +94,7 @@ public class MatchVoteDto {
 
 	@Getter
 	@AllArgsConstructor
-	public static class MatchPogVoteCandidateResponse {
+	public static class MatchPogVoteCandidate {
 		private List<PlayerInformation> information;
 	}
 }

--- a/src/main/java/com/lckback/lckforall/vote/dto/SetVoteDto.java
+++ b/src/main/java/com/lckback/lckforall/vote/dto/SetVoteDto.java
@@ -1,5 +1,6 @@
 package com.lckback.lckforall.vote.dto;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import lombok.AllArgsConstructor;
@@ -9,8 +10,22 @@ public class SetVoteDto {
 
 	@Getter
 	@AllArgsConstructor
+	public static class SetPogVoteCandidate {
+		private Integer setIndex;
+		private List<SetVoteDto.PlayerInformation> candidates;
+	}
+
+	@Getter
+	@AllArgsConstructor
 	public static class SetPogVoteCandidateResponse {
-		private List<SetVoteDto.PlayerInformation> information;
+		private List<SetPogVoteCandidate> information;
+
+		public void addCandidates(SetPogVoteCandidate candidates){
+			information.add(candidates);
+		}
+		public SetPogVoteCandidateResponse() {
+			information = new ArrayList<SetPogVoteCandidate>();
+		}
 	}
 
 	@Getter
@@ -19,8 +34,6 @@ public class SetVoteDto {
 		private String kakaoUserId;
 
 		private Long matchId;
-
-		private Integer setIndex;
 
 	}
 	@Getter

--- a/src/main/java/com/lckback/lckforall/vote/dto/SetVoteDto.java
+++ b/src/main/java/com/lckback/lckforall/vote/dto/SetVoteDto.java
@@ -12,19 +12,21 @@ public class SetVoteDto {
 	@AllArgsConstructor
 	public static class SetPogVoteCandidate {
 		private Integer setIndex;
-		private List<SetVoteDto.PlayerInformation> candidates;
+		private List<SetVoteDto.PlayerInformation> information;
 	}
 
 	@Getter
 	@AllArgsConstructor
-	public static class SetPogVoteCandidateResponse {
-		private List<SetPogVoteCandidate> information;
+	public static class PogVoteCandidateResponse {
+		private MatchVoteDto.MatchPogVoteCandidate matchPogVoteCandidate;
+		private List<SetPogVoteCandidate> setPogVoteCandidates;
 
 		public void addCandidates(SetPogVoteCandidate candidates){
-			information.add(candidates);
+			setPogVoteCandidates.add(candidates);
 		}
-		public SetPogVoteCandidateResponse() {
-			information = new ArrayList<SetPogVoteCandidate>();
+		public PogVoteCandidateResponse(MatchVoteDto.MatchPogVoteCandidate candidate) {
+			setPogVoteCandidates = new ArrayList<SetPogVoteCandidate>();
+			matchPogVoteCandidate = candidate;
 		}
 	}
 

--- a/src/main/java/com/lckback/lckforall/vote/service/VoteService.java
+++ b/src/main/java/com/lckback/lckforall/vote/service/VoteService.java
@@ -107,19 +107,17 @@ public class VoteService {
 		matchVoteRepository.save(vote);
 	}
 
-	public MatchVoteDto.MatchPogVoteCandidateResponse getMatchPogCandidate(
-		MatchVoteDto.MatchPredictionCandidateDto dto) {
-		String kakaoUserId = dto.getKakaoUserId();
+	public MatchVoteDto.MatchPogVoteCandidate getMatchPogCandidate(
+		String kakaoUserId, Long matchId) {
 		User user = userRepository.findByKakaoUserId(kakaoUserId)
 			.orElseThrow(() -> new RestApiException(UserErrorCode.NOT_EXIST_USER));
 		Long userId = user.getId();
-		Long matchId = dto.getMatchId();
 
 		// 투표를 이미 한 경우 (투표한 선수의 정보 리턴)
 		if (matchPogVoteRepository.votedPlayerByMatchIdAndUserId(matchId, userId).isPresent()) {
 			Player votedPlayer = matchPogVoteRepository.votedPlayerByMatchIdAndUserId(matchId, userId)
 				.orElseThrow(() -> new RestApiException(VoteErrorCode.NOT_EXIST_VOTE));
-			MatchVoteDto.MatchPogVoteCandidateResponse response = new MatchVoteDto.MatchPogVoteCandidateResponse(
+			MatchVoteDto.MatchPogVoteCandidate response = new MatchVoteDto.MatchPogVoteCandidate(
 				Collections.singletonList(new MatchVoteDto.PlayerInformation(
 					votedPlayer.getId(),
 					votedPlayer.getProfileImageUrl(),
@@ -142,7 +140,7 @@ public class VoteService {
 			SeasonTeam seasonTeam1 = seasonTeamRepository.findBySeasonAndTeam(match.getSeason(), match.getTeam1())
 				.orElseThrow(() -> new RestApiException(TeamErrorCode.NOT_EXISTS_TEAM));
 
-			return new MatchVoteDto.MatchPogVoteCandidateResponse(
+			return new MatchVoteDto.MatchPogVoteCandidate(
 				seasonTeam1.getSeasonTeamPlayers().stream()
 					.filter(seasonTeamPlayer -> seasonTeamPlayer.getPlayer().getRole() == PlayerRole.LCK_ROSTER)
 					.map(seasonTeamPlayer -> new MatchVoteDto.PlayerInformation(
@@ -155,7 +153,7 @@ public class VoteService {
 		SeasonTeam seasonTeam2 = seasonTeamRepository.findBySeasonAndTeam(match.getSeason(), match.getTeam2())
 			.orElseThrow(() -> new RestApiException(TeamErrorCode.NOT_EXISTS_TEAM));
 
-		return new MatchVoteDto.MatchPogVoteCandidateResponse(
+		return new MatchVoteDto.MatchPogVoteCandidate(
 			seasonTeam2.getSeasonTeamPlayers().stream()
 				.filter(seasonTeamPlayer -> seasonTeamPlayer.getPlayer().getRole() == PlayerRole.LCK_ROSTER)
 				.map(seasonTeamPlayer -> new MatchVoteDto.PlayerInformation(
@@ -216,7 +214,7 @@ public class VoteService {
 
 	// pog-player가 set내에 존재할때 로직 처리
 
-	public SetVoteDto.SetPogVoteCandidateResponse getSetPogCandidate(SetVoteDto.VoteCandidateDto dto) {
+	public SetVoteDto.PogVoteCandidateResponse getSetPogCandidate(SetVoteDto.VoteCandidateDto dto) {
 		String kakaoUserId = dto.getKakaoUserId();
 		User user = userRepository.findByKakaoUserId(kakaoUserId)
 			.orElseThrow(() -> new RestApiException(UserErrorCode.NOT_EXIST_USER));
@@ -226,8 +224,8 @@ public class VoteService {
 		List<Set> sets = setRepository.findByMatchId(matchId);
 		Match match = matchRepository.findById(matchId)
 			.orElseThrow(() -> new RestApiException(MatchErrorCode.NOT_EXIST_MATCH));
-
-		SetVoteDto.SetPogVoteCandidateResponse response = new SetVoteDto.SetPogVoteCandidateResponse();
+		MatchVoteDto.MatchPogVoteCandidate matchPogVoteCandidate = getMatchPogCandidate(kakaoUserId,matchId);
+		SetVoteDto.PogVoteCandidateResponse response = new SetVoteDto.PogVoteCandidateResponse(matchPogVoteCandidate);
 		for(Set set:sets){
 			// 투표를 이미 한 경우 (투표한 선수의 정보 리턴)
 			if (setPogVoteRepository.votedPlayerBySetIdAndUserId(set.getId(), userId).isPresent()) {

--- a/src/main/java/com/lckback/lckforall/vote/service/VoteService.java
+++ b/src/main/java/com/lckback/lckforall/vote/service/VoteService.java
@@ -131,9 +131,10 @@ public class VoteService {
 		Match match = matchRepository.findById(matchId)
 			.orElseThrow(() -> new RestApiException(MatchErrorCode.NOT_EXIST_MATCH));
 		// match pog vote 시간이 아닌 경우
-		if(!match.getMatchPogVotable()){
-			throw new RestApiException(VoteErrorCode.NOT_VOTE_TIME);
-		}
+		/* 데모데이를 위해 제약 조건 해제*/
+		// if(!match.getMatchPogVotable()){
+		// 	throw new RestApiException(VoteErrorCode.NOT_VOTE_TIME);
+		// }
 
 		// 투표를 하지 않았고 투표 시간이 남은 경우
 		if (match.getMatchResult().equals(MatchResult.TEAM1_WIN)) { // team1 win
@@ -174,9 +175,10 @@ public class VoteService {
 			.orElseThrow(() -> new RestApiException(MatchErrorCode.NOT_EXIST_MATCH));
 
 		// match pog vote 시간이 아닌경우
-		if(!match.getMatchPogVotable()){
-			throw new RestApiException(VoteErrorCode.NOT_VOTE_TIME);
-		}
+		/* 데모데이를 위해 제약 조건 해제*/
+		// if(!match.getMatchPogVotable()){
+		// 	throw new RestApiException(VoteErrorCode.NOT_VOTE_TIME);
+		// }
 
 		// 승리 팀의 플레이어에게만 투표 가능 (team1 승리 경우)
 		if(match.getMatchResult().equals(MatchResult.TEAM1_WIN)){
@@ -239,9 +241,10 @@ public class VoteService {
 			return response;
 		}
 		// 투표를 시간이 아닌경우
-		if (!set.getVotable()) {
-			throw new RestApiException(VoteErrorCode.NOT_VOTE_TIME);
-		}
+		/* 데모데이를 위해 제약 조건 해제*/
+		// if (!set.getVotable()) {
+		// 	throw new RestApiException(VoteErrorCode.NOT_VOTE_TIME);
+		// }
 		// 투표를 하지 않았고 투표 시간이 남은 경우
 		if (set.getWinnerTeam().equals(match.getTeam1())) { // team1 win
 			SeasonTeam seasonTeam1 = seasonTeamRepository.findBySeasonAndTeam(match.getSeason(), match.getTeam1())
@@ -281,9 +284,9 @@ public class VoteService {
 		Match match = matchRepository.findById(dto.getMatchId())
 			.orElseThrow(() -> new RestApiException(MatchErrorCode.NOT_EXIST_MATCH));
 
-		if(!set.getVotable()){ // 투표 시간이 아닌 경우
-			throw new RestApiException(VoteErrorCode.NOT_VOTE_TIME);
-		}
+		// if(!set.getVotable()){ // 투표 시간이 아닌 경우
+		// 	throw new RestApiException(VoteErrorCode.NOT_VOTE_TIME);
+		// }
 
 		// 승리 팀의 플레이어에게만 투표 가능 (team1 승리 경우)
 		if(set.getWinnerTeam() == match.getTeam1()){


### PR DESCRIPTION
## 개요
API 수정사항에 있는 Pog 후보 api 수정
## 작업사항
- match pog candidates api 삭제 후 해당 로직을 set pog candidates로 수정
- set pog candidate api에서 matchId만을 가지고 match pog candidate, set pog candidate 정보가 모두 나오도록 수정
## 변경로직

### 변경 전
votes/match-pog/candidates?match-id=
votes/set-pog/candidates?match-id=

### 변경 후
votes/pog/candidates?match-id=
하나의 api로 합침

## 사용방법

## 기타