### PR TITLE
[Refactor/#245] Migration From MySQL to MongoDB

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ dependencies {
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+    // mongodb
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.0'
+
     // websocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
 

--- a/src/main/java/com/lckback/lckforall/LckForAllApplication.java
+++ b/src/main/java/com/lckback/lckforall/LckForAllApplication.java
@@ -8,9 +8,11 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableMongoAuditing
 @Slf4j
 public class LckForAllApplication {
 

--- a/src/main/java/com/lckback/lckforall/user/model/User.java
+++ b/src/main/java/com/lckback/lckforall/user/model/User.java
@@ -105,9 +105,6 @@ public class User extends BaseEntity {
 	@OneToMany(mappedBy = "user", orphanRemoval = true)
 	private List<SetPogVote> setPogVotes = new ArrayList<>();
 
-	@OneToMany(mappedBy = "user", orphanRemoval = true)
-	private List<ChatMessage> chatMessages = new ArrayList<>();
-
 	public void updateNickname(String nickname) {
 		this.nickname = nickname;
 	}

--- a/src/main/java/com/lckback/lckforall/viewing/controller/ChatController.java
+++ b/src/main/java/com/lckback/lckforall/viewing/controller/ChatController.java
@@ -70,7 +70,7 @@ public class ChatController {
             @Parameter(name = "size", description = "query string(RequestParam) - 몇 개씩 불러올지 개수를 세는 변수 (1 이상 자연수로 설정)"),
     })
     public ApiResponse<ChatDTO.ChatMessageListResponse> getChatMessage(@RequestHeader(name = "Authorization") String accessToken,
-                                                                @PathVariable(name = "room_id") Long roomId,
+                                                                @PathVariable(name = "room_id") String roomId,
                                                                 @RequestParam(name = "page") Integer page,
                                                                 @RequestParam(name = "size") Integer size) {
         String kakaoUserId = authService.getKakaoUserId(accessToken);

--- a/src/main/java/com/lckback/lckforall/viewing/converter/ChatConverter.java
+++ b/src/main/java/com/lckback/lckforall/viewing/converter/ChatConverter.java
@@ -5,8 +5,11 @@ import com.lckback.lckforall.user.model.User;
 import com.lckback.lckforall.viewing.dto.ChatDTO;
 import com.lckback.lckforall.viewing.model.ChatMessage;
 import com.lckback.lckforall.viewing.model.ChatRoom;
+import com.lckback.lckforall.viewing.model.ViewingParty;
 import org.springframework.data.domain.Page;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class ChatConverter {
@@ -15,10 +18,10 @@ public class ChatConverter {
         return ChatRoom.builder().build();
     }
 
-    public static ChatDTO.ChatRoomResponse toChatRoomResponse(ChatRoom chatRoom, Boolean isExist){
+    public static ChatDTO.ChatRoomResponse toChatRoomResponse(ChatRoom chatRoom, ViewingParty viewingParty, Boolean isExist){
         return ChatDTO.ChatRoomResponse.builder()
                 .roomId(chatRoom.getId())
-                .viewingPartyName(chatRoom.getViewingParty().getName())
+                .viewingPartyName(viewingParty.getName())
                 .isExist(isExist)
                 .build();
     }
@@ -29,22 +32,23 @@ public class ChatConverter {
                 .build();
     }
 
-    public static ChatDTO.ChatMessageListResponse toChatMessageListResponse(Page<ChatMessage> chatMessageList, User user, ChatRoom chatRoom, Boolean isLast, Integer totalPage) {
+    public static ChatDTO.ChatMessageListResponse toChatMessageListResponse(Page<ChatMessage> chatMessageList, User user, ViewingParty viewingParty, Boolean isLast, Integer totalPage) {
         List<ChatDTO.ChatMessageResponse> chatList = chatMessageList.stream().map(ChatConverter::toChatMessageResponse).toList();
         return ChatDTO.ChatMessageListResponse.builder()
                 .isLast(isLast)
                 .totalPage(totalPage)
-                .viewingPartyName(chatRoom.getViewingParty().getName())
+                .viewingPartyName(viewingParty.getName())
                 .receiverName(user.getNickname())
                 .receiverTeam(user.getTeam().getTeamName())
+                .receiverProfileImage(user.getProfileImageUrl())
                 .chatMessageList(chatList)
                 .build();
     }
 
     public static ChatDTO.ChatMessageResponse toChatMessageResponse(ChatMessage chatMessage) {
         return ChatDTO.ChatMessageResponse.builder()
-                .createdAt(chatMessage.getCreatedAt())
-                .senderName(chatMessage.getUser().getNickname())
+                .createdAt(chatMessage.getTime())
+                .senderName(chatMessage.getSenderName())
                 .message(chatMessage.getContent())
                 .build();
     }

--- a/src/main/java/com/lckback/lckforall/viewing/dto/ChatDTO.java
+++ b/src/main/java/com/lckback/lckforall/viewing/dto/ChatDTO.java
@@ -3,7 +3,9 @@ package com.lckback.lckforall.viewing.dto;
 import lombok.*;
 import org.springframework.web.socket.WebSocketSession;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -23,20 +25,20 @@ public class ChatDTO {
         }
 
         private Message.MessageType type;
-        private Long chatRoomId;
+        private String chatRoomId;
         private String senderName;
         private String message;
     }
 
     @Getter
     public static class ChatRoomResponse {
-        private Long roomId;
+        private String roomId;
         private String viewingPartyName;
         private Boolean isExist;
         private Set<WebSocketSession> sessions = new HashSet<>();
 
         @Builder
-        public ChatRoomResponse(Long roomId, String viewingPartyName, Boolean isExist) {
+        public ChatRoomResponse(String roomId, String viewingPartyName, Boolean isExist) {
             this.roomId = roomId;
             this.viewingPartyName = viewingPartyName;
             this.isExist = isExist;
@@ -54,6 +56,7 @@ public class ChatDTO {
         String viewingPartyName;
         String receiverName;
         String receiverTeam;
+        String receiverProfileImage;
         List<ChatMessageResponse> chatMessageList;
     }
     @Builder
@@ -62,7 +65,7 @@ public class ChatDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class ChatMessageResponse{
-        LocalDateTime createdAt;
+        Date createdAt;
         String senderName;
         String message;
     }

--- a/src/main/java/com/lckback/lckforall/viewing/model/ChatMessage.java
+++ b/src/main/java/com/lckback/lckforall/viewing/model/ChatMessage.java
@@ -1,45 +1,36 @@
 package com.lckback.lckforall.viewing.model;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.lckback.lckforall.base.model.BaseEntity;
 import com.lckback.lckforall.user.model.User;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.data.mongodb.core.mapping.Document;
 
-@Getter
+import java.time.LocalDateTime;
+import java.util.Date;
+
 @Builder
-@Entity
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ChatMessage extends BaseEntity {
+@Data
+@Document(collection = "chat")
+@EntityListeners(AuditingEntityListener.class)
+public class ChatMessage {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private String id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "chat_room_id", nullable = false)
-    private ChatRoom chatRoom;
+    private String roomId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    private Long senderId;
 
-    @Column(nullable = false)
+    private String senderName;
+
     private String content;
 
-    public void setChatRoom(ChatRoom chatRoom) {
-        if(this.chatRoom != null) {
-            chatRoom.getMessages().remove(this);
-        }
-        this.chatRoom = chatRoom;
-        chatRoom.getMessages().add(this);
-    }
-
-    public void setUser(User user) {
-        if(this.user != null) {
-            user.getChatMessages().remove(this);
-        }
-        this.user = user;
-        user.getChatMessages().add(this);
-    }
-
+    private Date time;
 }

--- a/src/main/java/com/lckback/lckforall/viewing/model/ChatRoom.java
+++ b/src/main/java/com/lckback/lckforall/viewing/model/ChatRoom.java
@@ -3,35 +3,27 @@ package com.lckback.lckforall.viewing.model;
 import com.lckback.lckforall.base.model.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.mapping.Document;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-@Getter
 @Builder
-@Entity
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ChatRoom extends BaseEntity {
+@Data
+@Document(collection = "room")
+public class ChatRoom {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private String id;
 
-    @ManyToOne
-    @JoinColumn(name = "viewing_party_id", nullable = false)
-    private ViewingParty viewingParty;
+    private Long viewingPartyId;
 
-    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL)
-    private List<ChatMessage> messages = new ArrayList<>();
+    // 해당 뷰잉 파티에 질문하는 사람이 만든 방
+    private Long userId;
 
-    @OneToOne(mappedBy = "chatRoom", cascade = CascadeType.ALL)
-    private Participate participants;
+    private LocalDateTime createdAt;
 
-    public void setViewingParty(ViewingParty viewingParty) {
-        if(this.viewingParty != null) {
-            viewingParty.getChatRooms().remove(this);
-        }
-        this.viewingParty = viewingParty;
-        viewingParty.getChatRooms().add(this);
-    }
+    private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/lckback/lckforall/viewing/model/Participate.java
+++ b/src/main/java/com/lckback/lckforall/viewing/model/Participate.java
@@ -29,10 +29,6 @@ public class Participate extends BaseEntity {
 	@JoinColumn(name = "USER_ID", nullable = false)
 	private User user;
 
-	@OneToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "chatroom_id")
-	private ChatRoom chatRoom;
-
 	public void setUser(User user) {
 		if(this.user != null){
 			user.getParticipatingViewingParties().remove(this);
@@ -44,7 +40,4 @@ public class Participate extends BaseEntity {
 		this.viewingParty = viewingParty;
 	}
 
-	public void setChatRoom(ChatRoom chatRoom) {
-		this.chatRoom = chatRoom;
-	}
 }

--- a/src/main/java/com/lckback/lckforall/viewing/model/ViewingParty.java
+++ b/src/main/java/com/lckback/lckforall/viewing/model/ViewingParty.java
@@ -72,8 +72,6 @@ public class ViewingParty extends BaseEntity {
 	@OneToMany(mappedBy = "viewingParty", orphanRemoval = true)
 	private List<Participate> participates = new ArrayList<>();
 
-	@OneToMany(mappedBy = "viewingParty", orphanRemoval = true)
-	private List<ChatRoom> chatRooms = new ArrayList<>();
 	public void setUser(User user) {
 		if(this.user != null) {
 			user.getHostingViewingParties().remove(this);

--- a/src/main/java/com/lckback/lckforall/viewing/repository/ChatMessageRepository.java
+++ b/src/main/java/com/lckback/lckforall/viewing/repository/ChatMessageRepository.java
@@ -5,8 +5,9 @@ import com.lckback.lckforall.viewing.model.ChatRoom;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import reactor.core.publisher.Flux;
 
-public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
-
-    Page<ChatMessage> findAllByChatRoomOrderByCreatedAtDesc(ChatRoom chatRoom, Pageable pageable);
+public interface ChatMessageRepository extends MongoRepository<ChatMessage,String> {
+    Page<ChatMessage> findAllByRoomIdOrderByTimeDesc(String chatRoomId, Pageable pageable);
 }

--- a/src/main/java/com/lckback/lckforall/viewing/repository/ChatRoomRepository.java
+++ b/src/main/java/com/lckback/lckforall/viewing/repository/ChatRoomRepository.java
@@ -3,10 +3,13 @@ package com.lckback.lckforall.viewing.repository;
 import com.lckback.lckforall.viewing.model.ChatMessage;
 import com.lckback.lckforall.viewing.model.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.mongodb.repository.MongoRepository;
 
 import java.util.List;
+import java.util.Optional;
 
-public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+public interface ChatRoomRepository extends MongoRepository<ChatRoom, String> {
 
-    Boolean existsByMessages(List<ChatMessage> chatMessages);
+//    Boolean existsByMessages(List<ChatMessage> chatMessages);
+    Optional<ChatRoom> findByUserIdAndViewingPartyId(Long viewingPartyId, Long userId);
 }

--- a/src/main/java/com/lckback/lckforall/viewing/service/ChatService.java
+++ b/src/main/java/com/lckback/lckforall/viewing/service/ChatService.java
@@ -10,10 +10,9 @@ public interface ChatService {
 
     ChatDTO.ChatRoomResponse createOwnerChatRoom(String kakaoUserId, Long viewingPartyId, String participantKakaoUserId);
 
-
     public <T> void sendMessage(WebSocketSession session, T message);
 
-    ChatDTO.ChatMessageListResponse getChatMessage(String kakaoUserId, Long roomId, Integer page, Integer size);
+    ChatDTO.ChatMessageListResponse getChatMessage(String kakaoUserId, String roomId, Integer page, Integer size);
 
     User findUserOfChat(ChatDTO.Message chatMessage);
 


### PR DESCRIPTION
## 개요
MongoDB로 채팅 관련 데이터베이스 마이그레이션
## 작업사항
- 참여자 입장에서 뷰잉파티에 참여하지 않은 사용자도 채팅을 가능하게 수정했습니다.
- 개최자 입장에서 뷰잉파티에 참여한 사용자만 채팅을 가능하게 수정했습니다.
- MongoDB 특성에 맞춰 ChatRoom 식별자를 String 타입으로 변경했습니다.
- 저의 계정으로 Mongo Atlas Free Tier로 임시 배포 했습니다.
## 변경로직

### 변경 전

### 변경 후

## 사용방법
- EC2 보안그룹에서 27017 포트 열어주세요!
## 기타
- 규모가 커질경우 MongoDB 용량에 대해 논의해보면 좋을것 같습니다.