### PR TITLE
[Refactor/#261] fix pog result structure

### DIFF
--- a/src/main/java/com/lckback/lckforall/match/controller/PogController.java
+++ b/src/main/java/com/lckback/lckforall/match/controller/PogController.java
@@ -26,26 +26,26 @@ public class PogController {
 
 	private final PogService pogService;
 
-	@Operation(summary = "매치 pog 반환 API", description = "해당 매치의 pog를 반환합니다")
-	@PostMapping("/match")
+	@Operation(summary = "매치/세트 pog 결과 반환 API", description = "해당 매치의 pog를 반환합니다")
+	@PostMapping("/result")
 	public ResponseEntity<ApiResponse<PogInfoDto.PogResponse>> getMatchPog( // match의 pog 투표 결과 선정된 player를 반환
 		@RequestHeader("Authorization") String token,
 		@RequestBody PogInfoDto.MatchPogRequest request) {
-		PogInfoDto.PogResponse response = pogService.findMatchPog(request.toDto());
+		PogInfoDto.PogResponse response = pogService.findPog(request.toDto());
 
 		return ResponseEntity.ok()
 			.body(ApiResponse.createSuccess(response));
 	}
 
-	@Operation(summary = "세트 pog 반환 API", description = "해당 세트의 pog를 반환합니다")
-	@PostMapping("/set")
-	public ResponseEntity<ApiResponse<PogInfoDto.PogResponse>> getSetPog(// match의 pog 투표 결과 선정된 player를 반환
-		@RequestHeader("Authorization") String token,
-		@RequestParam("set-index") Integer setIndex,
-		@RequestBody PogInfoDto.MatchPogRequest request) {
-		PogInfoDto.PogResponse response = pogService.findSetPog(request.toDto(), setIndex);
-
-		return ResponseEntity.ok()
-			.body(ApiResponse.createSuccess(response));
-	}
+	// @Operation(summary = "세트 pog 반환 API", description = "해당 세트의 pog를 반환합니다")
+	// @PostMapping("/set")
+	// public ResponseEntity<ApiResponse<PogInfoDto.PogDTO>> getSetPog(// match의 pog 투표 결과 선정된 player를 반환
+	// 	@RequestHeader("Authorization") String token,
+	// 	@RequestParam("set-index") Integer setIndex,
+	// 	@RequestBody PogInfoDto.MatchPogRequest request) {
+	// 	PogInfoDto.PogDTO response = pogService.findSetPog(request.toDto(), setIndex);
+	//
+	// 	return ResponseEntity.ok()
+	// 		.body(ApiResponse.createSuccess(response));
+	// }
 }

--- a/src/main/java/com/lckback/lckforall/match/dto/PogInfoDto.java
+++ b/src/main/java/com/lckback/lckforall/match/dto/PogInfoDto.java
@@ -1,31 +1,66 @@
 package com.lckback.lckforall.match.dto;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.lckback.lckforall.match.model.Match;
+import com.lckback.lckforall.player.model.Player;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 public class PogInfoDto {
+
 	@Getter
 	@AllArgsConstructor
-	public static class PogResponse {
-		private Long id;
-
-		private String name;
-
-		private String profileImageUrl;
-
+	public static class PogResponse{
 		private String seasonInfo;
 
 		private Integer matchNumber;
 
 		private LocalDateTime matchDate;
 
-		public static PogResponse create(Long pogId, String name, String profileImageUrl, String seasonInfo,
-			Integer matchNumber, LocalDateTime matchDate) {
-			return new PogResponse(pogId, name, profileImageUrl, seasonInfo, matchNumber, matchDate);
+		private List<SetPogDTO> setPogResponses;
+
+		private MatchPogDTO matchPogResponse;
+
+		public PogResponse(Match match){
+			seasonInfo = match.getSeason().getName();
+			matchNumber = match.getMatchNumber();
+			matchDate = match.getMatchDate();
+			setPogResponses = new ArrayList<SetPogDTO>();
 		}
+		public void addSetPog(Player player, Integer setIndex){
+			setPogResponses.add(new SetPogDTO(setIndex, player.getId(),player.getName(), player.getProfileImageUrl()));
+		}
+		public void setMatchPog(Player player){
+			matchPogResponse = new MatchPogDTO(player.getId(),player.getName(), player.getProfileImageUrl());
+		}
+	}
+	@Getter
+	@AllArgsConstructor
+	public static class SetPogDTO {
+		private Integer SetIndex;
+
+		private Long PlayerId;
+
+		private String name;
+
+		private String profileImageUrl;
+
+	}
+	@Getter
+	@AllArgsConstructor
+	public static class MatchPogDTO {
+
+		private Long PlayerId;
+
+		private String name;
+
+		private String profileImageUrl;
+
 	}
 
 	@Getter


### PR DESCRIPTION

## 개요

프런트 요청 사항에 따른 pog 결과 반환 통합

## 작업사항

match-pog, set-pog 결과를 match-id를 받아서 한번에 반환 하도록 수정

## 변경로직

/pog/match, /pog/set -> 를 /pog/result로 통합 

match-id를 넘겨주면 그 매치에 해당되는 match-pog, List<set-pog> 정보 반환

### 변경 전

### 변경 후

## 사용방법

## 기타